### PR TITLE
Add initial for arrays and a contains operator

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -140,3 +140,25 @@ func (ce *CallExpression) String() string {
 
 	return out.String()
 }
+
+type ArrayLiteral struct {
+	Token    token.Token // the '[' token
+	Elements []Expression
+}
+
+func (al *ArrayLiteral) expressionNode()      {}
+func (al *ArrayLiteral) TokenLiteral() string { return al.Token.Literal }
+func (al *ArrayLiteral) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, el := range al.Elements {
+		elements = append(elements, el.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -132,8 +132,8 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 		return evalDotExpression(left, right)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.REGEXP_OBJ:
 		return evalStringRegexpInfixExpression(operator, left, right)
-	case left.Type() == object.ARRAY_OBJ && right.Type() == object.STRING_OBJ:
-		return evalStringArrayInfixExpression(operator, left, right)
+	case left.Type() == object.ARRAY_OBJ:
+		return evalArrayInfixExpression(operator, left, right)
 	case operator == "==":
 		return nativeBoolToBooleanObject(left == right)
 	case operator == "!=":
@@ -229,7 +229,7 @@ func arrayContains(arr *object.Array, obj object.Object) (bool, error) {
 	return false, nil
 }
 
-func evalStringArrayInfixExpression(operator string, left, right object.Object) object.Object {
+func evalArrayInfixExpression(operator string, left, right object.Object) object.Object {
 	// defer untrace(trace("evalStringArrayInfixExpression", operator, left, right))
 
 	leftVal := left.(*object.Array)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -76,6 +76,13 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 
 		return applyFunction(obj, args)
 
+	case *ast.ArrayLiteral:
+		elements := evalExpressions(node.Elements, env)
+		if len(elements) == 1 && isError(elements[0]) {
+			return elements[0]
+		}
+		return &object.Array{Elements: elements}
+
 	default:
 		return newError("unhandled type: %T", node)
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -106,6 +106,8 @@ func TestContainsOperator(t *testing.T) {
 		expected bool
 	}{
 		{`["llamas","alpacas"] @> 'alpacas'`, true},
+		{`["llamas","alpacas"] @> 'sheep'`, false},
+		{`[1,2,3] @> 2`, true},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -100,6 +100,20 @@ func TestDotOperator(t *testing.T) {
 	}
 }
 
+func TestContainsOperator(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`["llamas","alpacas"] @> 'alpacas'`, true},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testBooleanObject(t, evaluated, tt.expected)
+	}
+}
+
 func testEval(input string) object.Object {
 	return testEvalWithEnv(input, object.NewEnvironment())
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -74,6 +74,15 @@ func (l *Lexer) NextToken() token.Token {
 		} else {
 			tok = newToken(token.ILLEGAL, l.ch)
 		}
+	case '@':
+		if l.peekChar() == '>' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.CONTAINS, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
 	case '.':
 		tok = newToken(token.DOT, l.ch)
 	case '"':
@@ -89,6 +98,10 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.LPAREN, l.ch)
 	case ')':
 		tok = newToken(token.RPAREN, l.ch)
+	case '[':
+		tok = newToken(token.LBRACKET, l.ch)
+	case ']':
+		tok = newToken(token.RBRACKET, l.ch)
 	case 0:
 		tok.Literal = ""
 		tok.Type = token.EOF

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -79,6 +79,18 @@ func TestLexingRegexps(t *testing.T) {
 	})
 }
 
+func TestLexingArrays(t *testing.T) {
+	expectTokens(t, `["llamas", "alpacas"] @> "alpacas"`, []tokenExpectation{
+		{token.LBRACKET, "["},
+		{token.STRING, "llamas"},
+		{token.COMMA, ","},
+		{token.STRING, "alpacas"},
+		{token.RBRACKET, "]"},
+		{token.CONTAINS, "@>"},
+		{token.STRING, "alpacas"},
+	})
+}
+
 func expectTokens(t *testing.T, input string, expect []tokenExpectation) {
 	t.Helper()
 	l := New(input)

--- a/object/object.go
+++ b/object/object.go
@@ -1,8 +1,10 @@
 package object
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 type ObjectType string
@@ -18,6 +20,7 @@ const (
 
 	STRUCT_OBJ   = "STRUCT"
 	FUNCTION_OBJ = "FUNCTION"
+	ARRAY_OBJ    = "ARRAY"
 )
 
 type Object interface {
@@ -71,6 +74,26 @@ type Struct struct {
 
 func (s *Struct) Type() ObjectType { return STRUCT_OBJ }
 func (s *Struct) String() string   { return "struct" }
+
+type Array struct {
+	Elements []Object
+}
+
+func (ao *Array) Type() ObjectType { return ARRAY_OBJ }
+func (ao *Array) String() string {
+	var out bytes.Buffer
+
+	elements := []string{}
+	for _, e := range ao.Elements {
+		elements = append(elements, e.String())
+	}
+
+	out.WriteString("[")
+	out.WriteString(strings.Join(elements, ", "))
+	out.WriteString("]")
+
+	return out.String()
+}
 
 type Error struct {
 	Message string

--- a/object/object.go
+++ b/object/object.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 )
@@ -26,47 +27,57 @@ const (
 type Object interface {
 	Type() ObjectType
 	String() string
+	Equals(o Object) bool
 }
 
 type Integer struct {
 	Value int64
 }
 
-func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
-func (i *Integer) String() string   { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) Type() ObjectType     { return INTEGER_OBJ }
+func (i *Integer) String() string       { return fmt.Sprintf("%d", i.Value) }
+func (i *Integer) Equals(o Object) bool { return i.String() == o.String() }
 
 type Boolean struct {
 	Value bool
 }
 
-func (b *Boolean) Type() ObjectType { return BOOLEAN_OBJ }
-func (b *Boolean) String() string   { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) Type() ObjectType     { return BOOLEAN_OBJ }
+func (b *Boolean) String() string       { return fmt.Sprintf("%t", b.Value) }
+func (b *Boolean) Equals(o Object) bool { return b == o }
 
 type String struct {
 	Value string
 }
 
-func (s *String) Type() ObjectType { return STRING_OBJ }
-func (s *String) String() string   { return fmt.Sprintf("%q", s.Value) }
+func (s *String) Type() ObjectType     { return STRING_OBJ }
+func (s *String) String() string       { return fmt.Sprintf("%q", s.Value) }
+func (s *String) Equals(o Object) bool { return s.String() == o.String() }
 
 type Regexp struct {
 	*regexp.Regexp
 }
 
-func (r *Regexp) Type() ObjectType { return REGEXP_OBJ }
-func (r *Regexp) String() string   { return r.Regexp.String() }
+func (r *Regexp) Type() ObjectType     { return REGEXP_OBJ }
+func (r *Regexp) String() string       { return r.Regexp.String() }
+func (r *Regexp) Equals(o Object) bool { return r.String() == o.String() }
 
 type Null struct{}
 
 func (n *Null) Type() ObjectType { return NULL_OBJ }
 func (n *Null) String() string   { return "null" }
+func (n *Null) Equals(o Object) bool {
+	_, ok := o.(*Null)
+	return ok
+}
 
 type Function struct {
 	Fn func(args []Object) Object
 }
 
-func (f *Function) Type() ObjectType { return FUNCTION_OBJ }
-func (f *Function) String() string   { return "function" }
+func (f *Function) Type() ObjectType     { return FUNCTION_OBJ }
+func (f *Function) String() string       { return "function" }
+func (f *Function) Equals(o Object) bool { return f == o }
 
 type Struct struct {
 	Props map[string]Object
@@ -74,6 +85,9 @@ type Struct struct {
 
 func (s *Struct) Type() ObjectType { return STRUCT_OBJ }
 func (s *Struct) String() string   { return "struct" }
+func (s *Struct) Equals(o Object) bool {
+	return reflect.DeepEqual(s, o)
+}
 
 type Array struct {
 	Elements []Object
@@ -94,10 +108,14 @@ func (ao *Array) String() string {
 
 	return out.String()
 }
+func (ao *Array) Equals(o Object) bool {
+	return reflect.DeepEqual(ao, o)
+}
 
 type Error struct {
 	Message string
 }
 
-func (e *Error) Type() ObjectType { return ERROR_OBJ }
-func (e *Error) String() string   { return "ERROR: " + e.Message }
+func (e *Error) Type() ObjectType     { return ERROR_OBJ }
+func (e *Error) String() string       { return "ERROR: " + e.Message }
+func (e *Error) Equals(o Object) bool { return e == o }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -269,6 +269,63 @@ func TestCallExpressionParameterParsing(t *testing.T) {
 	}
 }
 
+func TestParsingEmptyArrayLiterals(t *testing.T) {
+	input := "[]"
+
+	l := lexer.New(input)
+	p := New(l)
+	expr := p.Parse()
+	checkParserErrors(t, p)
+
+	array, ok := expr.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("exp not ast.ArrayLiteral. got=%T", expr)
+	}
+
+	if len(array.Elements) != 0 {
+		t.Errorf("len(array.Elements) not 0. got=%d", len(array.Elements))
+	}
+}
+
+func TestParsingArrayLiterals(t *testing.T) {
+	input := `["llamas", "alpacas"]`
+
+	l := lexer.New(input)
+	p := New(l)
+	expr := p.Parse()
+	checkParserErrors(t, p)
+
+	array, ok := expr.(*ast.ArrayLiteral)
+	if !ok {
+		t.Fatalf("exp not ast.ArrayLiteral. got=%T", expr)
+	}
+
+	if len(array.Elements) != 2 {
+		t.Fatalf("len(array.Elements) not 2. got=%d", len(array.Elements))
+	}
+
+	testIdentifierOrString(t, array.Elements[0], "llamas")
+	testIdentifierOrString(t, array.Elements[1], "alpacas")
+}
+
+func TestParsingContainsOperator(t *testing.T) {
+	input := `["llamas", "alpacas"] @> "llamas"`
+
+	l := lexer.New(input)
+	p := New(l)
+	expr := p.Parse()
+	checkParserErrors(t, p)
+
+	iexpr, ok := expr.(*ast.InfixExpression)
+	if !ok {
+		t.Fatalf("exp is not ast.InfixExpression. got=%T(%s)", expr, expr)
+	}
+
+	if iexpr.Operator != "@>" {
+		t.Fatalf("exp doesn't have contains operator. got=%s", iexpr.Operator)
+	}
+}
+
 func testInfixExpression(t *testing.T, exp ast.Expression, left interface{},
 	operator string, right interface{}) bool {
 

--- a/token/token.go
+++ b/token/token.go
@@ -20,15 +20,18 @@ const (
 	NOT_EQ    = "!="
 	RE_EQ     = "=~"
 	RE_NOT_EQ = "!~"
+	CONTAINS  = "@>"
 
 	// Boolean Operators
 	AND = "&&"
 	OR  = "||"
 
 	// Delimiters
-	COMMA  = ","
-	LPAREN = "("
-	RPAREN = ")"
+	COMMA    = ","
+	LPAREN   = "("
+	RPAREN   = ")"
+	LBRACKET = "["
+	RBRACKET = "]"
 
 	// Keywords
 	TRUE  = "TRUE"


### PR DESCRIPTION
Adds support for arrays and the `@>` contains operator:

```c
["alpacas", "llamas"] @> "alpacas"
=> true
```