### PR TITLE
README: fix Usage example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ build.tag =~ /^v/
 package main
 
 import (
-  "github.com/buildkite/conditional/lexer"
-  "github.com/buildkite/conditional/parser"
-  "github.com/buildkite/conditional/evaluator"
+	"log"
+
+	"github.com/buildkite/conditional/evaluator"
+	"github.com/buildkite/conditional/lexer"
+	"github.com/buildkite/conditional/object"
+	"github.com/buildkite/conditional/parser"
 )
 
 func main() {
@@ -60,16 +63,16 @@ func main() {
 	expr := p.Parse()
 
 	if errs := p.Errors(); len(errs) > 0 {
-	  log.Fatal(errs...)
-  }
+		log.Fatal(errs...)
+	}
 
-  obj := evaluator.Eval(expr, object.Struct{
-    "build": object.Struct{
-      "message": &object.String{"llamas rock, and so do alpacas"},
-    },
-  })
+	obj := evaluator.Eval(expr, object.Struct{
+		"build": object.Struct{
+			"message": &object.String{"llamas rock, and so do alpacas"},
+		},
+	})
 
-  log.Printf("Result: %#v", obj)
+	log.Printf("Result: %#v", obj)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ func main() {
 	expr := p.Parse()
 
 	if errs := p.Errors(); len(errs) > 0 {
-		log.Fatal(errs...)
+		log.Fatal(errs)
 	}
 
 	obj := evaluator.Eval(expr, object.Struct{


### PR DESCRIPTION
Minor fixes to get the Usage example code to [work in Go Playground](https://play.golang.org/p/oIUhwxpns5R);

- package imports
- `log.Fatal()` arg type

`[]string` can't be passed variadically to a function expecting `[]interface{}`

> cannot use errs (type []string) as type []interface {} in argument to log.Fatal

The error strings can be converted to interfaces with a few lines of code, but the next problem is `log.Fatal` doesn't include newlines between its variadic parameters.

Better to pass the slice as a slice, and have it logged as a slice.
