### PR TITLE
feat: Add conditional root API

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -25,7 +25,11 @@ func Validate(expression string, ctx Context) error {
 	if err != nil {
 		return err
 	}
-	return validateExpression(expr, entryPoint)
+	ctx.EntryPoint = entryPoint
+	if err := validateExpression(expr, entryPoint); err != nil {
+		return err
+	}
+	return validateBooleanResult(expr, ctx)
 }
 
 // Evaluate evaluates expression in the selected Buildkite context.
@@ -95,7 +99,25 @@ func validateExpression(expr ast.Expression, entryPoint EntryPoint) error {
 	if err := validateEnvCalls(expr); err != nil {
 		return err
 	}
+	if err := validateOperators(expr); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateBooleanResult(expr ast.Expression, ctx Context) error {
+	result := evaluator.Eval(expr, buildScope(ctx))
+	switch result := result.(type) {
+	case *object.Boolean:
+		return nil
+	case *object.Error:
+		return &Error{Kind: ErrorKindEvaluation, Message: result.Message}
+	default:
+		return &Error{
+			Kind:    ErrorKindResult,
+			Message: fmt.Sprintf("expected boolean result, got %s", result.Type()),
+		}
+	}
 }
 
 func validateEnvCalls(expr ast.Expression) error {
@@ -130,6 +152,35 @@ func validateEnvCalls(expr ast.Expression) error {
 	case *ast.ArrayLiteral:
 		for _, element := range expr.Elements {
 			if err := validateEnvCalls(element); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateOperators(expr ast.Expression) error {
+	switch expr := expr.(type) {
+	case *ast.PrefixExpression:
+		return validateOperators(expr.Right)
+	case *ast.InfixExpression:
+		if expr.Operator == "@>" {
+			return &Error{Kind: ErrorKindValidation, Message: "@> is not Buildkite conditional syntax"}
+		}
+		if err := validateOperators(expr.Left); err != nil {
+			return err
+		}
+		return validateOperators(expr.Right)
+	case *ast.CallExpression:
+		for _, arg := range expr.Arguments {
+			if err := validateOperators(arg); err != nil {
+				return err
+			}
+		}
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if err := validateOperators(element); err != nil {
 				return err
 			}
 		}
@@ -225,45 +276,47 @@ func envNameArg(args []object.Object) (string, *object.Error) {
 func flatAssignments(ctx Context) object.Struct {
 	build := ctx.Build
 	assignments := object.Struct{
-		"build.id":                            stringValue(build.ID),
-		"build.state":                         stringValue(build.State),
-		"build.fixed":                         boolValue(build.Fixed),
-		"build.blocked_state":                 stringValue(build.BlockedState),
-		"build.source":                        stringValue(build.Source),
-		"build.source_event":                  stringValue(sourceEvent(ctx)),
-		"build.source_action":                 stringValue(sourceAction(ctx)),
-		"build.branch":                        stringValue(build.Branch),
-		"build.tag":                           stringValue(build.Tag),
-		"build.message":                       stringValue(build.Message),
-		"build.commit":                        stringValue(build.Commit),
-		"build.number":                        intValue(build.Number),
-		"build.creator.id":                    stringValue(build.Creator.ID),
-		"build.creator.name":                  stringValue(build.Creator.Name),
-		"build.creator.email":                 stringValue(build.Creator.Email),
-		"build.creator.teams":                 stringArrayValue(build.Creator.Teams),
-		"build.creator.verified":              boolValue(build.Creator.Verified),
-		"build.author.id":                     stringValue(build.Author.ID),
-		"build.author.name":                   stringValue(build.Author.Name),
-		"build.author.email":                  stringValue(build.Author.Email),
-		"build.author.teams":                  stringArrayValue(build.Author.Teams),
-		"build.scm.author.name":               stringValue(build.SCM.AuthorName),
-		"build.scm.author.email":              stringValue(build.SCM.AuthorEmail),
-		"build.scm.committer.name":            stringValue(build.SCM.CommitterName),
-		"build.scm.committer.email":           stringValue(build.SCM.CommitterEmail),
-		"build.pull_request.id":               stringValue(build.PullRequest.ID),
-		"build.pull_request.base_branch":      stringValue(build.PullRequest.BaseBranch),
-		"build.pull_request.draft":            boolValue(build.PullRequest.Draft),
-		"build.pull_request.label":            stringValue(pullRequestLabel(ctx)),
-		"build.pull_request.labels":           stringArrayValue(build.PullRequest.Labels),
-		"build.pull_request.repository":       stringValue(build.PullRequest.Repository),
-		"build.pull_request.repository.fork":  boolValue(build.PullRequest.RepositoryFork),
-		"build.merge_queue.base_branch":       stringValue(build.MergeQueue.BaseBranch),
-		"build.merge_queue.base_commit":       stringValue(build.MergeQueue.BaseCommit),
-		"pipeline.id":                         stringValue(ctx.Pipeline.ID),
-		"pipeline.name":                       stringValue(ctx.Pipeline.Name),
-		"pipeline.slug":                       stringValue(ctx.Pipeline.Slug),
-		"pipeline.default_branch":             stringValue(ctx.Pipeline.DefaultBranch),
-		"pipeline.repository":                 stringValue(ctx.Pipeline.Repository),
+		"build.id":                           stringValue(build.ID),
+		"build.state":                        stringValue(build.State),
+		"build.fixed":                        boolValue(build.Fixed),
+		"build.blocked_state":                stringValue(build.BlockedState),
+		"build.source":                       stringValue(build.Source),
+		"build.source_event":                 stringValue(sourceEvent(ctx)),
+		"build.source_action":                stringValue(sourceAction(ctx)),
+		"build.branch":                       stringValue(build.Branch),
+		"build.tag":                          stringValue(build.Tag),
+		"build.message":                      stringValue(build.Message),
+		"build.commit":                       stringValue(build.Commit),
+		"build.number":                       intValue(build.Number),
+		"build.creator.id":                   stringValue(build.Creator.ID),
+		"build.creator.name":                 stringValue(build.Creator.Name),
+		"build.creator.email":                stringValue(build.Creator.Email),
+		"build.creator.teams":                stringArrayValue(build.Creator.Teams),
+		"build.creator.verified":             boolValue(build.Creator.Verified),
+		"build.author.id":                    stringValue(build.Author.ID),
+		"build.author.name":                  stringValue(build.Author.Name),
+		"build.author.email":                 stringValue(build.Author.Email),
+		"build.author.teams":                 stringArrayValue(build.Author.Teams),
+		"build.scm.author.name":              stringValue(build.SCM.AuthorName),
+		"build.scm.author.email":             stringValue(build.SCM.AuthorEmail),
+		"build.scm.committer.name":           stringValue(build.SCM.CommitterName),
+		"build.scm.committer.email":          stringValue(build.SCM.CommitterEmail),
+		"build.pull_request.id":              stringValue(build.PullRequest.ID),
+		"build.pull_request.base_branch":     stringValue(build.PullRequest.BaseBranch),
+		"build.pull_request.draft":           boolValue(build.PullRequest.Draft),
+		"build.pull_request.label":           stringValue(pullRequestLabel(ctx)),
+		"build.pull_request.labels":          stringArrayValue(build.PullRequest.Labels),
+		"build.pull_request.repository":      stringValue(build.PullRequest.Repository),
+		"build.pull_request.repository.fork": boolValue(build.PullRequest.RepositoryFork),
+		"build.merge_queue.base_branch":      stringValue(build.MergeQueue.BaseBranch),
+		"build.merge_queue.base_commit":      stringValue(build.MergeQueue.BaseCommit),
+		"pipeline.id":                        stringValue(ctx.Pipeline.ID),
+		"pipeline.name":                      stringValue(ctx.Pipeline.Name),
+		"pipeline.slug":                      stringValue(ctx.Pipeline.Slug),
+		"pipeline.default_branch":            stringValue(ctx.Pipeline.DefaultBranch),
+		"pipeline.repository":                stringValue(ctx.Pipeline.Repository),
+		// Upstream Build::Condition exposes these in its base assignment table,
+		// even though the public docs describe them as notification variables.
 		"pipeline.started_passing":            boolValue(ctx.Pipeline.StartedPassing),
 		"pipeline.started_failing":            boolValue(ctx.Pipeline.StartedFailing),
 		"pipeline.next_finished_build_exists": boolValue(ctx.Pipeline.NextFinishedBuildExists),

--- a/conditional.go
+++ b/conditional.go
@@ -36,6 +36,10 @@ func Evaluate(expression string, ctx Context) (bool, error) {
 	}
 	ctx.EntryPoint = entryPoint
 
+	if strings.TrimSpace(expression) == "" && isNotificationEntryPoint(entryPoint) {
+		return true, nil
+	}
+
 	result, err := evaluate(expression, ctx)
 	if err != nil && isNotificationEntryPoint(entryPoint) {
 		return false, nil
@@ -88,6 +92,43 @@ func validateExpression(expr ast.Expression, entryPoint EntryPoint) error {
 			Message: fmt.Sprintf("step variables are not available for entry point %q", entryPoint),
 		}
 	}
+	if err := validateEnvCalls(expr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateEnvCalls(expr ast.Expression) error {
+	switch expr := expr.(type) {
+	case *ast.PrefixExpression:
+		return validateEnvCalls(expr.Right)
+	case *ast.InfixExpression:
+		if err := validateEnvCalls(expr.Left); err != nil {
+			return err
+		}
+		return validateEnvCalls(expr.Right)
+	case *ast.CallExpression:
+		if (expr.Function == "env" || expr.Function == "build.env") && len(expr.Arguments) == 1 {
+			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok && unsupportedBuildkiteEnv(arg.Value) {
+				return &Error{
+					Kind:    ErrorKindValidation,
+					Message: fmt.Sprintf("%q is not a supported Buildkite environment variable", arg.Value),
+				}
+			}
+		}
+		for _, arg := range expr.Arguments {
+			if err := validateEnvCalls(arg); err != nil {
+				return err
+			}
+		}
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if err := validateEnvCalls(element); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -371,15 +412,121 @@ func pullRequestLabel(ctx Context) *string {
 	return ctx.Build.PullRequest.Label
 }
 
+var supportedBuildkiteEnv = map[string]struct{}{
+	"BUILDKITE_BRANCH":                               {},
+	"BUILDKITE_TAG":                                  {},
+	"BUILDKITE_MESSAGE":                              {},
+	"BUILDKITE_COMMIT":                               {},
+	"BUILDKITE_PIPELINE_SLUG":                        {},
+	"BUILDKITE_PIPELINE_NAME":                        {},
+	"BUILDKITE_PIPELINE_ID":                          {},
+	"BUILDKITE_ORGANIZATION_SLUG":                    {},
+	"BUILDKITE_TRIGGERED_FROM_BUILD_ID":              {},
+	"BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER":          {},
+	"BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG":   {},
+	"BUILDKITE_TRIGGERED_FROM_BUILD_JOB_ID":          {},
+	"BUILDKITE_REBUILT_FROM_BUILD_ID":                {},
+	"BUILDKITE_REBUILT_FROM_BUILD_NUMBER":            {},
+	"BUILDKITE_REPO":                                 {},
+	"BUILDKITE_PULL_REQUEST":                         {},
+	"BUILDKITE_PULL_REQUEST_BASE_BRANCH":             {},
+	"BUILDKITE_PULL_REQUEST_REPO":                    {},
+	"BUILDKITE_PULL_REQUEST_LABELS":                  {},
+	"BUILDKITE_PULL_REQUEST_USING_MERGE_REFSPEC":     {},
+	"BUILDKITE_MERGE_QUEUE_BASE_BRANCH":              {},
+	"BUILDKITE_MERGE_QUEUE_BASE_COMMIT":              {},
+	"BUILDKITE_GIT_DIFF_BASE":                        {},
+	"BUILDKITE_GITHUB_ACTION":                        {},
+	"BUILDKITE_GITHUB_COMMENT_ID":                    {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_ID":                 {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_TASK":               {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_ENVIRONMENT":        {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_PAYLOAD":            {},
+	"BUILDKITE_GITHUB_EVENT":                         {},
+	"BUILDKITE_GITHUB_REVIEW_ID":                     {},
+	"BUILDKITE_GITHUB_CHECK_RUN_CONCLUSION":          {},
+	"BUILDKITE_GITHUB_CHECK_RUN_NAME":                {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_STATUS_ENVIRONMENT": {},
+	"BUILDKITE_GITHUB_DEPLOYMENT_STATUS_STATE":       {},
+	"BUILDKITE_GITHUB_RELEASE_DRAFT":                 {},
+	"BUILDKITE_GITHUB_RELEASE_PRERELEASE":            {},
+	"BUILDKITE_GITHUB_RELEASE_TAG":                   {},
+	"BUILDKITE_GITHUB_REVIEW_STATE":                  {},
+}
+
 func mergedEnv(ctx Context) map[string]string {
-	env := make(map[string]string, len(ctx.ProjectEnv)+len(ctx.BuildEnv))
-	for key, value := range ctx.ProjectEnv {
-		env[key] = value
-	}
-	for key, value := range ctx.BuildEnv {
+	env := make(map[string]string, len(ctx.ProjectEnv)+len(ctx.BuildEnv)+len(supportedBuildkiteEnv))
+	mergeUserEnv(env, ctx.ProjectEnv)
+	mergeUserEnv(env, ctx.BuildEnv)
+	for key, value := range builtinEnv(ctx) {
 		env[key] = value
 	}
 	return env
+}
+
+func mergeUserEnv(env map[string]string, values map[string]string) {
+	for key, value := range values {
+		if unsupportedBuildkiteEnv(key) {
+			continue
+		}
+		env[key] = value
+	}
+}
+
+func unsupportedBuildkiteEnv(key string) bool {
+	if !strings.HasPrefix(key, "BUILDKITE_") {
+		return false
+	}
+	_, ok := supportedBuildkiteEnv[key]
+	return !ok
+}
+
+func builtinEnv(ctx Context) map[string]string {
+	env := map[string]string{}
+
+	setString(env, "BUILDKITE_BRANCH", ctx.Build.Branch)
+	setString(env, "BUILDKITE_TAG", ctx.Build.Tag)
+	if ctx.Build.Tag == nil {
+		env["BUILDKITE_TAG"] = ""
+	}
+	setString(env, "BUILDKITE_MESSAGE", ctx.Build.Message)
+	if ctx.Build.Message == nil {
+		env["BUILDKITE_MESSAGE"] = ""
+	}
+	setString(env, "BUILDKITE_COMMIT", ctx.Build.Commit)
+	setString(env, "BUILDKITE_REPO", ctx.Pipeline.Repository)
+	setString(env, "BUILDKITE_PIPELINE_SLUG", ctx.Pipeline.Slug)
+	setString(env, "BUILDKITE_PIPELINE_ID", ctx.Pipeline.ID)
+	setString(env, "BUILDKITE_ORGANIZATION_SLUG", ctx.Organization.Slug)
+
+	if ctx.Build.PullRequest.ID == nil || *ctx.Build.PullRequest.ID == "" {
+		env["BUILDKITE_PULL_REQUEST"] = "false"
+	} else {
+		env["BUILDKITE_PULL_REQUEST"] = *ctx.Build.PullRequest.ID
+	}
+	setStringOrBlank(env, "BUILDKITE_PULL_REQUEST_BASE_BRANCH", ctx.Build.PullRequest.BaseBranch)
+	setStringOrBlank(env, "BUILDKITE_PULL_REQUEST_REPO", ctx.Build.PullRequest.Repository)
+	if ctx.Build.PullRequest.Labels != nil {
+		env["BUILDKITE_PULL_REQUEST_LABELS"] = strings.Join(ctx.Build.PullRequest.Labels, ",")
+	}
+	setStringOrBlank(env, "BUILDKITE_MERGE_QUEUE_BASE_BRANCH", ctx.Build.MergeQueue.BaseBranch)
+	setStringOrBlank(env, "BUILDKITE_MERGE_QUEUE_BASE_COMMIT", ctx.Build.MergeQueue.BaseCommit)
+
+	return env
+}
+
+func setString(env map[string]string, key string, value *string) {
+	if value != nil {
+		env[key] = *value
+	}
+}
+
+func setStringOrBlank(env map[string]string, key string, value *string) {
+	if value == nil {
+		env[key] = ""
+		return
+	}
+	env[key] = *value
 }
 
 func normalizeEntryPoint(entryPoint EntryPoint) (EntryPoint, error) {

--- a/conditional.go
+++ b/conditional.go
@@ -1,0 +1,350 @@
+package conditional
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/conditional/ast"
+	"github.com/buildkite/conditional/evaluator"
+	"github.com/buildkite/conditional/lexer"
+	"github.com/buildkite/conditional/object"
+	"github.com/buildkite/conditional/parser"
+)
+
+// Validate parses expression for the selected Buildkite context.
+func Validate(expression string, ctx Context) error {
+	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(expression) == "" {
+		return nil
+	}
+
+	expr, err := parse(expression)
+	if err != nil {
+		return err
+	}
+	return validateExpression(expr, entryPoint)
+}
+
+// Evaluate evaluates expression in the selected Buildkite context.
+func Evaluate(expression string, ctx Context) (bool, error) {
+	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
+	if err != nil {
+		return false, err
+	}
+	ctx.EntryPoint = entryPoint
+
+	result, err := evaluate(expression, ctx)
+	if err != nil && isNotificationEntryPoint(entryPoint) {
+		return false, nil
+	}
+	return result, err
+}
+
+func evaluate(expression string, ctx Context) (bool, error) {
+	expr, err := parse(expression)
+	if err != nil {
+		return false, err
+	}
+	if err := validateExpression(expr, ctx.EntryPoint); err != nil {
+		return false, err
+	}
+
+	result := evaluator.Eval(expr, buildScope(ctx))
+	switch result := result.(type) {
+	case *object.Boolean:
+		return result.Value, nil
+	case *object.Error:
+		return false, &Error{Kind: ErrorKindEvaluation, Message: result.Message}
+	default:
+		return false, &Error{
+			Kind:    ErrorKindResult,
+			Message: fmt.Sprintf("expected boolean result, got %s", result.Type()),
+		}
+	}
+}
+
+func parse(expression string) (ast.Expression, error) {
+	l := lexer.New(expression)
+	p := parser.New(l)
+	expr := p.Parse()
+
+	if errs := p.Errors(); len(errs) > 0 {
+		return nil, &Error{Kind: ErrorKindParse, Message: strings.Join(errs, "; ")}
+	}
+	if expr == nil {
+		return nil, &Error{Kind: ErrorKindParse, Message: "empty expression"}
+	}
+
+	return expr, nil
+}
+
+func validateExpression(expr ast.Expression, entryPoint EntryPoint) error {
+	if !stepAllowed(entryPoint) && referencesRoot(expr, "step") {
+		return &Error{
+			Kind:    ErrorKindValidation,
+			Message: fmt.Sprintf("step variables are not available for entry point %q", entryPoint),
+		}
+	}
+	return nil
+}
+
+func referencesRoot(expr ast.Expression, root string) bool {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		return expr.Value == root
+	case *ast.PrefixExpression:
+		return referencesRoot(expr.Right, root)
+	case *ast.InfixExpression:
+		return referencesRoot(expr.Left, root) || referencesRoot(expr.Right, root)
+	case *ast.CallExpression:
+		if expr.Function == root || strings.HasPrefix(expr.Function, root+".") {
+			return true
+		}
+		for _, arg := range expr.Arguments {
+			if referencesRoot(arg, root) {
+				return true
+			}
+		}
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if referencesRoot(element, root) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func buildScope(ctx Context) object.Struct {
+	env := mergedEnv(ctx)
+
+	scope := object.Struct{
+		"env": object.Function(func(args []object.Object) object.Object {
+			if len(args) != 1 {
+				return &object.Error{Message: fmt.Sprintf("wrong number of arguments for env: got %d, want 1", len(args))}
+			}
+			name, ok := args[0].(*object.String)
+			if !ok {
+				return &object.Error{Message: "env argument must be a string"}
+			}
+			return &object.String{Value: env[name.Value]}
+		}),
+		"build":        buildObject(ctx),
+		"pipeline":     pipelineObject(ctx.Pipeline),
+		"organization": organizationObject(ctx.Organization),
+	}
+
+	if stepAllowed(ctx.EntryPoint) {
+		scope["step"] = stepObject(ctx.Step)
+	}
+
+	return scope
+}
+
+func buildObject(ctx Context) object.Struct {
+	build := ctx.Build
+	return object.Struct{
+		"id":            stringValue(build.ID),
+		"state":         stringValue(build.State),
+		"fixed":         boolValue(build.Fixed),
+		"blocked_state": stringValue(build.BlockedState),
+		"source":        stringValue(build.Source),
+		"source_event":  stringValue(sourceEvent(ctx)),
+		"source_action": stringValue(sourceAction(ctx)),
+		"branch":        stringValue(build.Branch),
+		"tag":           stringValue(build.Tag),
+		"message":       stringValue(build.Message),
+		"commit":        stringValue(build.Commit),
+		"number":        intValue(build.Number),
+		"creator":       actorObject(build.Creator, true),
+		"author":        actorObject(build.Author, false),
+		"scm": object.Struct{
+			"author": object.Struct{
+				"name":  stringValue(build.SCM.AuthorName),
+				"email": stringValue(build.SCM.AuthorEmail),
+			},
+			"committer": object.Struct{
+				"name":  stringValue(build.SCM.CommitterName),
+				"email": stringValue(build.SCM.CommitterEmail),
+			},
+		},
+		"pull_request": object.Struct{
+			"id":          stringValue(build.PullRequest.ID),
+			"base_branch": stringValue(build.PullRequest.BaseBranch),
+			"draft":       boolValue(build.PullRequest.Draft),
+			"label":       stringValue(pullRequestLabel(ctx)),
+			"labels":      stringArrayValue(build.PullRequest.Labels),
+			"repository": object.Struct{
+				"fork": boolValue(build.PullRequest.RepositoryFork),
+			},
+		},
+		"merge_queue": object.Struct{
+			"base_branch": stringValue(build.MergeQueue.BaseBranch),
+			"base_commit": stringValue(build.MergeQueue.BaseCommit),
+		},
+	}
+}
+
+func actorObject(actor Actor, includeVerified bool) object.Struct {
+	out := object.Struct{
+		"id":    stringValue(actor.ID),
+		"name":  stringValue(actor.Name),
+		"email": stringValue(actor.Email),
+		"teams": stringArrayValue(actor.Teams),
+	}
+	if includeVerified {
+		out["verified"] = boolValue(actor.Verified)
+	}
+	return out
+}
+
+func pipelineObject(pipeline Pipeline) object.Struct {
+	return object.Struct{
+		"id":                         stringValue(pipeline.ID),
+		"slug":                       stringValue(pipeline.Slug),
+		"default_branch":             stringValue(pipeline.DefaultBranch),
+		"repository":                 stringValue(pipeline.Repository),
+		"started_passing":            boolValue(pipeline.StartedPassing),
+		"started_failing":            boolValue(pipeline.StartedFailing),
+		"next_finished_build_exists": boolValue(pipeline.NextFinishedBuildExists),
+	}
+}
+
+func organizationObject(organization Organization) object.Struct {
+	return object.Struct{
+		"id":   stringValue(organization.ID),
+		"slug": stringValue(organization.Slug),
+	}
+}
+
+func stepObject(step *Step) object.Struct {
+	if step == nil {
+		return object.Struct{
+			"id":      &object.Null{},
+			"key":     &object.Null{},
+			"type":    &object.Null{},
+			"label":   &object.Null{},
+			"state":   &object.Null{},
+			"outcome": &object.Null{},
+		}
+	}
+	return object.Struct{
+		"id":      stringValue(step.ID),
+		"key":     stringValue(step.Key),
+		"type":    stringValue(step.Type),
+		"label":   stringValue(step.Label),
+		"state":   stringValue(step.State),
+		"outcome": stringValue(step.Outcome),
+	}
+}
+
+func sourceEvent(ctx Context) *string {
+	if stringPtrValue(ctx.Build.Source) != "webhook" {
+		return nil
+	}
+	if ctx.Build.SourceEvent != nil {
+		return ctx.Build.SourceEvent
+	}
+	if value, ok := ctx.BuildEnv["BUILDKITE_GITHUB_EVENT"]; ok {
+		return &value
+	}
+	return nil
+}
+
+func sourceAction(ctx Context) *string {
+	if stringPtrValue(ctx.Build.Source) != "webhook" {
+		return nil
+	}
+	if ctx.Build.SourceAction != nil {
+		return ctx.Build.SourceAction
+	}
+	if value, ok := ctx.BuildEnv["BUILDKITE_GITHUB_ACTION"]; ok {
+		return &value
+	}
+	return nil
+}
+
+func pullRequestLabel(ctx Context) *string {
+	event := sourceEvent(ctx)
+	if event == nil || *event != "pull_request" {
+		return nil
+	}
+	return ctx.Build.PullRequest.Label
+}
+
+func mergedEnv(ctx Context) map[string]string {
+	env := make(map[string]string, len(ctx.ProjectEnv)+len(ctx.BuildEnv))
+	for key, value := range ctx.ProjectEnv {
+		env[key] = value
+	}
+	for key, value := range ctx.BuildEnv {
+		env[key] = value
+	}
+	return env
+}
+
+func normalizeEntryPoint(entryPoint EntryPoint) (EntryPoint, error) {
+	switch entryPoint {
+	case "", EntryPointBuildCondition:
+		return EntryPointBuildCondition, nil
+	case EntryPointBuildConditionWithStep, EntryPointBuildNotification, EntryPointStepNotification:
+		return entryPoint, nil
+	default:
+		return "", &Error{
+			Kind:    ErrorKindValidation,
+			Message: fmt.Sprintf("unknown entry point %q", entryPoint),
+		}
+	}
+}
+
+func stepAllowed(entryPoint EntryPoint) bool {
+	return entryPoint == EntryPointBuildConditionWithStep || entryPoint == EntryPointStepNotification
+}
+
+func isNotificationEntryPoint(entryPoint EntryPoint) bool {
+	return entryPoint == EntryPointBuildNotification || entryPoint == EntryPointStepNotification
+}
+
+func stringValue(value *string) object.Object {
+	if value == nil {
+		return &object.Null{}
+	}
+	return &object.String{Value: *value}
+}
+
+func stringPtrValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func boolValue(value *bool) object.Object {
+	if value == nil {
+		return &object.Null{}
+	}
+	return &object.Boolean{Value: *value}
+}
+
+func intValue(value *int) object.Object {
+	if value == nil {
+		return &object.Null{}
+	}
+	return &object.Integer{Value: int64(*value)}
+}
+
+func stringArrayValue(values []string) object.Object {
+	if values == nil {
+		return &object.Null{}
+	}
+
+	elements := make([]object.Object, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, &object.String{Value: value})
+	}
+	return &object.Array{Elements: elements}
+}

--- a/conditional.go
+++ b/conditional.go
@@ -108,7 +108,13 @@ func validateEnvCalls(expr ast.Expression) error {
 		}
 		return validateEnvCalls(expr.Right)
 	case *ast.CallExpression:
-		if (expr.Function == "env" || expr.Function == "build.env") && len(expr.Arguments) == 1 {
+		if expr.Function == "env" || expr.Function == "build.env" {
+			if len(expr.Arguments) != 1 {
+				return &Error{
+					Kind:    ErrorKindValidation,
+					Message: fmt.Sprintf("%s expects exactly one argument", expr.Function),
+				}
+			}
 			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok && unsupportedBuildkiteEnv(arg.Value) {
 				return &Error{
 					Kind:    ErrorKindValidation,
@@ -254,6 +260,7 @@ func flatAssignments(ctx Context) object.Struct {
 		"build.merge_queue.base_branch":       stringValue(build.MergeQueue.BaseBranch),
 		"build.merge_queue.base_commit":       stringValue(build.MergeQueue.BaseCommit),
 		"pipeline.id":                         stringValue(ctx.Pipeline.ID),
+		"pipeline.name":                       stringValue(ctx.Pipeline.Name),
 		"pipeline.slug":                       stringValue(ctx.Pipeline.Slug),
 		"pipeline.default_branch":             stringValue(ctx.Pipeline.DefaultBranch),
 		"pipeline.repository":                 stringValue(ctx.Pipeline.Repository),
@@ -337,6 +344,7 @@ func actorObject(actor Actor, includeVerified bool) object.Struct {
 func pipelineObject(pipeline Pipeline) object.Struct {
 	return object.Struct{
 		"id":                         stringValue(pipeline.ID),
+		"name":                       stringValue(pipeline.Name),
 		"slug":                       stringValue(pipeline.Slug),
 		"default_branch":             stringValue(pipeline.DefaultBranch),
 		"repository":                 stringValue(pipeline.Repository),
@@ -496,6 +504,7 @@ func builtinEnv(ctx Context) map[string]string {
 	setString(env, "BUILDKITE_COMMIT", ctx.Build.Commit)
 	setString(env, "BUILDKITE_REPO", ctx.Pipeline.Repository)
 	setString(env, "BUILDKITE_PIPELINE_SLUG", ctx.Pipeline.Slug)
+	setString(env, "BUILDKITE_PIPELINE_NAME", ctx.Pipeline.Name)
 	setString(env, "BUILDKITE_PIPELINE_ID", ctx.Pipeline.ID)
 	setString(env, "BUILDKITE_ORGANIZATION_SLUG", ctx.Organization.Slug)
 

--- a/conditional.go
+++ b/conditional.go
@@ -123,19 +123,14 @@ func buildScope(ctx Context) object.Struct {
 	env := mergedEnv(ctx)
 
 	scope := object.Struct{
-		"env": object.Function(func(args []object.Object) object.Object {
-			if len(args) != 1 {
-				return &object.Error{Message: fmt.Sprintf("wrong number of arguments for env: got %d, want 1", len(args))}
-			}
-			name, ok := args[0].(*object.String)
-			if !ok {
-				return &object.Error{Message: "env argument must be a string"}
-			}
-			return &object.String{Value: env[name.Value]}
-		}),
+		"env":          envFunction(env),
+		"build.env":    nullableEnvFunction(env),
 		"build":        buildObject(ctx),
 		"pipeline":     pipelineObject(ctx.Pipeline),
 		"organization": organizationObject(ctx.Organization),
+	}
+	for key, value := range flatAssignments(ctx) {
+		scope[key] = value
 	}
 
 	if stepAllowed(ctx.EntryPoint) {
@@ -143,6 +138,102 @@ func buildScope(ctx Context) object.Struct {
 	}
 
 	return scope
+}
+
+func envFunction(env map[string]string) object.Function {
+	return func(args []object.Object) object.Object {
+		name, err := envNameArg(args)
+		if err != nil {
+			return err
+		}
+		return &object.String{Value: env[name]}
+	}
+}
+
+func nullableEnvFunction(env map[string]string) object.Function {
+	return func(args []object.Object) object.Object {
+		name, err := envNameArg(args)
+		if err != nil {
+			return err
+		}
+		value, ok := env[name]
+		if !ok {
+			return &object.Null{}
+		}
+		return &object.String{Value: value}
+	}
+}
+
+func envNameArg(args []object.Object) (string, *object.Error) {
+	if len(args) != 1 {
+		return "", &object.Error{Message: fmt.Sprintf("wrong number of arguments for env: got %d, want 1", len(args))}
+	}
+	name, ok := args[0].(*object.String)
+	if !ok {
+		return "", &object.Error{Message: "env argument must be a string"}
+	}
+	return name.Value, nil
+}
+
+func flatAssignments(ctx Context) object.Struct {
+	build := ctx.Build
+	assignments := object.Struct{
+		"build.id":                            stringValue(build.ID),
+		"build.state":                         stringValue(build.State),
+		"build.fixed":                         boolValue(build.Fixed),
+		"build.blocked_state":                 stringValue(build.BlockedState),
+		"build.source":                        stringValue(build.Source),
+		"build.source_event":                  stringValue(sourceEvent(ctx)),
+		"build.source_action":                 stringValue(sourceAction(ctx)),
+		"build.branch":                        stringValue(build.Branch),
+		"build.tag":                           stringValue(build.Tag),
+		"build.message":                       stringValue(build.Message),
+		"build.commit":                        stringValue(build.Commit),
+		"build.number":                        intValue(build.Number),
+		"build.creator.id":                    stringValue(build.Creator.ID),
+		"build.creator.name":                  stringValue(build.Creator.Name),
+		"build.creator.email":                 stringValue(build.Creator.Email),
+		"build.creator.teams":                 stringArrayValue(build.Creator.Teams),
+		"build.creator.verified":              boolValue(build.Creator.Verified),
+		"build.author.id":                     stringValue(build.Author.ID),
+		"build.author.name":                   stringValue(build.Author.Name),
+		"build.author.email":                  stringValue(build.Author.Email),
+		"build.author.teams":                  stringArrayValue(build.Author.Teams),
+		"build.scm.author.name":               stringValue(build.SCM.AuthorName),
+		"build.scm.author.email":              stringValue(build.SCM.AuthorEmail),
+		"build.scm.committer.name":            stringValue(build.SCM.CommitterName),
+		"build.scm.committer.email":           stringValue(build.SCM.CommitterEmail),
+		"build.pull_request.id":               stringValue(build.PullRequest.ID),
+		"build.pull_request.base_branch":      stringValue(build.PullRequest.BaseBranch),
+		"build.pull_request.draft":            boolValue(build.PullRequest.Draft),
+		"build.pull_request.label":            stringValue(pullRequestLabel(ctx)),
+		"build.pull_request.labels":           stringArrayValue(build.PullRequest.Labels),
+		"build.pull_request.repository":       stringValue(build.PullRequest.Repository),
+		"build.pull_request.repository.fork":  boolValue(build.PullRequest.RepositoryFork),
+		"build.merge_queue.base_branch":       stringValue(build.MergeQueue.BaseBranch),
+		"build.merge_queue.base_commit":       stringValue(build.MergeQueue.BaseCommit),
+		"pipeline.id":                         stringValue(ctx.Pipeline.ID),
+		"pipeline.slug":                       stringValue(ctx.Pipeline.Slug),
+		"pipeline.default_branch":             stringValue(ctx.Pipeline.DefaultBranch),
+		"pipeline.repository":                 stringValue(ctx.Pipeline.Repository),
+		"pipeline.started_passing":            boolValue(ctx.Pipeline.StartedPassing),
+		"pipeline.started_failing":            boolValue(ctx.Pipeline.StartedFailing),
+		"pipeline.next_finished_build_exists": boolValue(ctx.Pipeline.NextFinishedBuildExists),
+		"organization.id":                     stringValue(ctx.Organization.ID),
+		"organization.slug":                   stringValue(ctx.Organization.Slug),
+	}
+
+	if stepAllowed(ctx.EntryPoint) {
+		step := stepObject(ctx.Step)
+		assignments["step.id"] = step["id"]
+		assignments["step.key"] = step["key"]
+		assignments["step.type"] = step["type"]
+		assignments["step.label"] = step["label"]
+		assignments["step.state"] = step["state"]
+		assignments["step.outcome"] = step["outcome"]
+	}
+
+	return assignments
 }
 
 func buildObject(ctx Context) object.Struct {
@@ -271,6 +362,10 @@ func sourceAction(ctx Context) *string {
 func pullRequestLabel(ctx Context) *string {
 	event := sourceEvent(ctx)
 	if event == nil || *event != "pull_request" {
+		return nil
+	}
+	action := sourceAction(ctx)
+	if action == nil || (*action != "labeled" && *action != "unlabeled") {
 		return nil
 	}
 	return ctx.Build.PullRequest.Label

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -1,0 +1,123 @@
+package conditional
+
+import (
+	"testing"
+)
+
+func TestEvaluateBuildCondition(t *testing.T) {
+	branch := "features/api"
+
+	got, err := Evaluate(`build.branch =~ /^features\//`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build:      Build{Branch: &branch},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluateDefaultsToBuildCondition(t *testing.T) {
+	branch := "features/api"
+
+	got, err := Evaluate(`build.branch == "features/api"`, Context{
+		Build: Build{Branch: &branch},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluateRejectsUnknownEntryPoint(t *testing.T) {
+	_, err := Evaluate(`true`, Context{EntryPoint: "unknown"})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestEvaluateMergesProjectEnvBeforeBuildEnv(t *testing.T) {
+	got, err := Evaluate(`env("DEPLOY_ENV") == "build" && env("EMPTY") == "" && env("MISSING") == ""`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		ProjectEnv: map[string]string{
+			"DEPLOY_ENV": "project",
+			"EMPTY":      "",
+		},
+		BuildEnv: map[string]string{
+			"DEPLOY_ENV": "build",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluateReturnsParseError(t *testing.T) {
+	_, err := Evaluate(`nope != == one`, Context{EntryPoint: EntryPointBuildCondition})
+	if !IsErrorKind(err, ErrorKindParse) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindParse)
+	}
+}
+
+func TestEvaluateReturnsResultErrorForNonBoolean(t *testing.T) {
+	_, err := Evaluate(`"not boolean"`, Context{EntryPoint: EntryPointBuildCondition})
+	if !IsErrorKind(err, ErrorKindResult) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindResult)
+	}
+}
+
+func TestNotificationEntryPointFailsClosed(t *testing.T) {
+	got, err := Evaluate(`nope != == one`, Context{EntryPoint: EntryPointBuildNotification})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if got {
+		t.Fatalf("Evaluate returned true, want false")
+	}
+
+	got, err = Evaluate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildNotification})
+	if err != nil {
+		t.Fatalf("Evaluate returned error for unavailable step variable: %v", err)
+	}
+	if got {
+		t.Fatalf("Evaluate returned true for unavailable step variable, want false")
+	}
+}
+
+func TestValidateAcceptsBlank(t *testing.T) {
+	if err := Validate("   ", Context{EntryPoint: EntryPointBuildCondition}); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestStepAvailabilityFollowsEntryPoint(t *testing.T) {
+	key := "deploy"
+
+	got, err := Evaluate(`step.key == "deploy"`, Context{
+		EntryPoint: EntryPointBuildConditionWithStep,
+		Step:       &Step{Key: &key},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+
+	err = Validate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildCondition})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
+	}
+
+	_, err = Evaluate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildCondition})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
+	}
+}

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -77,6 +77,77 @@ func TestEvaluateBuildEnvReturnsNullForMissingVariables(t *testing.T) {
 	}
 }
 
+func TestEvaluateDerivesSupportedBuildkiteEnv(t *testing.T) {
+	branch := "main"
+	tag := "v1.2.3"
+	message := "ship it"
+	commit := "abc123"
+	pipelineSlug := "deploy"
+	pipelineID := "018f"
+	repository := "git@github.com:acme/repo.git"
+	organizationSlug := "acme"
+	pullRequestID := "123"
+	pullRequestBaseBranch := "main"
+	mergeQueueBaseBranch := "main"
+	mergeQueueBaseCommit := "def456"
+
+	got, err := Evaluate(`build.env("BUILDKITE_BRANCH") == "main" &&
+		build.env("BUILDKITE_TAG") == "v1.2.3" &&
+		env("BUILDKITE_MESSAGE") == "ship it" &&
+		build.env("BUILDKITE_COMMIT") == "abc123" &&
+		build.env("BUILDKITE_PIPELINE_SLUG") == "deploy" &&
+		build.env("BUILDKITE_PIPELINE_ID") == "018f" &&
+		build.env("BUILDKITE_REPO") == "git@github.com:acme/repo.git" &&
+		build.env("BUILDKITE_ORGANIZATION_SLUG") == "acme" &&
+		build.env("BUILDKITE_PULL_REQUEST") == "123" &&
+		build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") == "main" &&
+		build.env("BUILDKITE_PULL_REQUEST_REPO") == "git@github.com:acme/repo.git" &&
+		build.env("BUILDKITE_PULL_REQUEST_LABELS") == "bug,deploy" &&
+		build.env("BUILDKITE_MERGE_QUEUE_BASE_BRANCH") == "main" &&
+		build.env("BUILDKITE_MERGE_QUEUE_BASE_COMMIT") == "def456"`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build: Build{
+			Branch:      &branch,
+			Tag:         &tag,
+			Message:     &message,
+			Commit:      &commit,
+			PullRequest: PullRequest{ID: &pullRequestID, BaseBranch: &pullRequestBaseBranch, Repository: &repository, Labels: []string{"bug", "deploy"}},
+			MergeQueue:  MergeQueue{BaseBranch: &mergeQueueBaseBranch, BaseCommit: &mergeQueueBaseCommit},
+		},
+		Pipeline:     Pipeline{Slug: &pipelineSlug, ID: &pipelineID, Repository: &repository},
+		Organization: Organization{Slug: &organizationSlug},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluateFiltersUnsupportedBuildkiteEnv(t *testing.T) {
+	_, err := Evaluate(`build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`, Context{
+		EntryPoint: EntryPointBuildCondition,
+	})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
+	}
+
+	got, err := Evaluate(`build.env(env("SECRET_NAME")) == null && env(env("SECRET_NAME")) == ""`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		BuildEnv: map[string]string{
+			"SECRET_NAME":                  "BUILDKITE_AGENT_ACCESS_TOKEN",
+			"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
 func TestEvaluatePullRequestRepositoryAndFork(t *testing.T) {
 	repository := "git@github.com:acme/repo.git"
 	fork := true
@@ -167,6 +238,16 @@ func TestNotificationEntryPointFailsClosed(t *testing.T) {
 	}
 	if got {
 		t.Fatalf("Evaluate returned true for unavailable step variable, want false")
+	}
+}
+
+func TestNotificationEntryPointAllowsBlankCondition(t *testing.T) {
+	got, err := Evaluate(` `, Context{EntryPoint: EntryPointBuildNotification})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
 	}
 }
 

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -59,6 +59,85 @@ func TestEvaluateMergesProjectEnvBeforeBuildEnv(t *testing.T) {
 	}
 }
 
+func TestEvaluateBuildEnvReturnsNullForMissingVariables(t *testing.T) {
+	got, err := Evaluate(`build.env("PROJECTED") == "fully" && build.env("EMPTY") == "" && build.env("MISSING") == null`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		ProjectEnv: map[string]string{
+			"PROJECTED": "fully",
+		},
+		BuildEnv: map[string]string{
+			"EMPTY": "",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluatePullRequestRepositoryAndFork(t *testing.T) {
+	repository := "git@github.com:acme/repo.git"
+	fork := true
+
+	got, err := Evaluate(`build.pull_request.repository == "git@github.com:acme/repo.git" && build.pull_request.repository.fork`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build: Build{
+			PullRequest: PullRequest{
+				Repository:     &repository,
+				RepositoryFork: &fork,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
+func TestEvaluatePullRequestLabelRequiresLabelAction(t *testing.T) {
+	source := "webhook"
+	event := "pull_request"
+	label := "test-gpu"
+	opened := "opened"
+	labeled := "labeled"
+
+	got, err := Evaluate(`build.pull_request.label == null`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build: Build{
+			Source:       &source,
+			SourceEvent:  &event,
+			SourceAction: &opened,
+			PullRequest:  PullRequest{Label: &label},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+
+	got, err = Evaluate(`build.pull_request.label == "test-gpu"`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build: Build{
+			Source:       &source,
+			SourceEvent:  &event,
+			SourceAction: &labeled,
+			PullRequest:  PullRequest{Label: &label},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
+	}
+}
+
 func TestEvaluateReturnsParseError(t *testing.T) {
 	_, err := Evaluate(`nope != == one`, Context{EntryPoint: EntryPointBuildCondition})
 	if !IsErrorKind(err, ErrorKindParse) {

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -82,6 +82,7 @@ func TestEvaluateDerivesSupportedBuildkiteEnv(t *testing.T) {
 	tag := "v1.2.3"
 	message := "ship it"
 	commit := "abc123"
+	pipelineName := "Deploy"
 	pipelineSlug := "deploy"
 	pipelineID := "018f"
 	repository := "git@github.com:acme/repo.git"
@@ -95,6 +96,7 @@ func TestEvaluateDerivesSupportedBuildkiteEnv(t *testing.T) {
 		build.env("BUILDKITE_TAG") == "v1.2.3" &&
 		env("BUILDKITE_MESSAGE") == "ship it" &&
 		build.env("BUILDKITE_COMMIT") == "abc123" &&
+		build.env("BUILDKITE_PIPELINE_NAME") == "Deploy" &&
 		build.env("BUILDKITE_PIPELINE_SLUG") == "deploy" &&
 		build.env("BUILDKITE_PIPELINE_ID") == "018f" &&
 		build.env("BUILDKITE_REPO") == "git@github.com:acme/repo.git" &&
@@ -114,7 +116,7 @@ func TestEvaluateDerivesSupportedBuildkiteEnv(t *testing.T) {
 			PullRequest: PullRequest{ID: &pullRequestID, BaseBranch: &pullRequestBaseBranch, Repository: &repository, Labels: []string{"bug", "deploy"}},
 			MergeQueue:  MergeQueue{BaseBranch: &mergeQueueBaseBranch, BaseCommit: &mergeQueueBaseCommit},
 		},
-		Pipeline:     Pipeline{Slug: &pipelineSlug, ID: &pipelineID, Repository: &repository},
+		Pipeline:     Pipeline{Name: &pipelineName, Slug: &pipelineSlug, ID: &pipelineID, Repository: &repository},
 		Organization: Organization{Slug: &organizationSlug},
 	})
 	if err != nil {
@@ -254,6 +256,20 @@ func TestNotificationEntryPointAllowsBlankCondition(t *testing.T) {
 func TestValidateAcceptsBlank(t *testing.T) {
 	if err := Validate("   ", Context{EntryPoint: EntryPointBuildCondition}); err != nil {
 		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestValidateRejectsMalformedEnvCalls(t *testing.T) {
+	tests := []string{
+		`env() == ""`,
+		`build.env("FOO", "BAR") == null`,
+	}
+
+	for _, expression := range tests {
+		err := Validate(expression, Context{EntryPoint: EntryPointBuildCondition})
+		if !IsErrorKind(err, ErrorKindValidation) {
+			t.Fatalf("Validate(%q) error = %v, want %s", expression, err, ErrorKindValidation)
+		}
 	}
 }
 

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -259,6 +259,13 @@ func TestValidateAcceptsBlank(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsNonBooleanResult(t *testing.T) {
+	err := Validate(`"not boolean"`, Context{EntryPoint: EntryPointBuildCondition})
+	if !IsErrorKind(err, ErrorKindResult) {
+		t.Fatalf("Validate error = %v, want %s", err, ErrorKindResult)
+	}
+}
+
 func TestValidateRejectsMalformedEnvCalls(t *testing.T) {
 	tests := []string{
 		`env() == ""`,
@@ -270,6 +277,45 @@ func TestValidateRejectsMalformedEnvCalls(t *testing.T) {
 		if !IsErrorKind(err, ErrorKindValidation) {
 			t.Fatalf("Validate(%q) error = %v, want %s", expression, err, ErrorKindValidation)
 		}
+	}
+}
+
+func TestValidateRejectsNonServerOperators(t *testing.T) {
+	branch := "main"
+
+	err := Validate(`["main"] @> build.branch`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build:      Build{Branch: &branch},
+	})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
+	}
+
+	_, err = Evaluate(`["main"] @> build.branch`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Build:      Build{Branch: &branch},
+	})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestPipelineTransitionFieldsFollowServerAssignmentTable(t *testing.T) {
+	startedPassing := true
+	startedFailing := false
+
+	got, err := Evaluate(`pipeline.started_passing && !pipeline.started_failing`, Context{
+		EntryPoint: EntryPointBuildCondition,
+		Pipeline: Pipeline{
+			StartedPassing: &startedPassing,
+			StartedFailing: &startedFailing,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatalf("Evaluate returned false, want true")
 	}
 }
 

--- a/context.go
+++ b/context.go
@@ -1,0 +1,116 @@
+package conditional
+
+// EntryPoint identifies the server path that is evaluating a conditional.
+type EntryPoint string
+
+const (
+	// EntryPointBuildCondition evaluates a Build::Condition without a step.
+	EntryPointBuildCondition EntryPoint = "build_condition"
+	// EntryPointBuildConditionWithStep evaluates a Build::Condition with a step.
+	EntryPointBuildConditionWithStep EntryPoint = "build_condition_with_step"
+	// EntryPointBuildNotification evaluates build notification deliverability.
+	EntryPointBuildNotification EntryPoint = "build_notification"
+	// EntryPointStepNotification evaluates step notification deliverability.
+	EntryPointStepNotification EntryPoint = "step_notification"
+)
+
+// Context contains the Buildkite values available to a conditional.
+type Context struct {
+	EntryPoint EntryPoint
+
+	Build        Build
+	Pipeline     Pipeline
+	Organization Organization
+	Step         *Step
+
+	// BuildEnv is build-scoped environment. ProjectEnv is pipeline/project
+	// environment. Matching Build::PipelineEnvironment, ProjectEnv is applied
+	// first, then BuildEnv overrides it.
+	BuildEnv   map[string]string
+	ProjectEnv map[string]string
+}
+
+// Build contains build values exposed to conditionals.
+type Build struct {
+	ID           *string
+	State        *string
+	Fixed        *bool
+	BlockedState *string
+	Source       *string
+	SourceEvent  *string
+	SourceAction *string
+	Branch       *string
+	Tag          *string
+	Message      *string
+	Commit       *string
+	Number       *int
+
+	Creator     Actor
+	Author      Actor
+	SCM         SCM
+	PullRequest PullRequest
+	MergeQueue  MergeQueue
+}
+
+// Actor contains server-resolved author or creator values. Email should contain
+// the value exposed through the server's build.*.email assignments, including
+// organization-preferred creator email resolution when applicable.
+type Actor struct {
+	ID       *string
+	Name     *string
+	Email    *string
+	Teams    []string
+	Verified *bool
+}
+
+// Pipeline contains pipeline values exposed to conditionals.
+type Pipeline struct {
+	ID                      *string
+	Slug                    *string
+	DefaultBranch           *string
+	Repository              *string
+	StartedPassing          *bool
+	StartedFailing          *bool
+	NextFinishedBuildExists *bool
+}
+
+// SCM contains source control author and committer values.
+type SCM struct {
+	AuthorName     *string
+	AuthorEmail    *string
+	CommitterName  *string
+	CommitterEmail *string
+}
+
+// PullRequest contains pull request values exposed to conditionals.
+type PullRequest struct {
+	ID             *string
+	BaseBranch     *string
+	Draft          *bool
+	Label          *string
+	Labels         []string
+	Repository     *string
+	RepositoryFork *bool
+}
+
+// MergeQueue contains merge queue values exposed to conditionals.
+type MergeQueue struct {
+	BaseBranch *string
+	BaseCommit *string
+}
+
+// Organization contains organization values exposed to conditionals.
+type Organization struct {
+	ID   *string
+	Slug *string
+}
+
+// Step contains step values exposed to step-aware conditionals.
+type Step struct {
+	ID      *string
+	Key     *string
+	Type    *string
+	Label   *string
+	State   *string
+	Outcome *string
+}

--- a/context.go
+++ b/context.go
@@ -66,6 +66,7 @@ type Actor struct {
 // Pipeline contains pipeline values exposed to conditionals.
 type Pipeline struct {
 	ID                      *string
+	Name                    *string
 	Slug                    *string
 	DefaultBranch           *string
 	Repository              *string

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,6 @@
+// Package conditional evaluates Buildkite conditional expressions.
+//
+// The public API models Buildkite's server-side conditional entrypoints while
+// the parser and evaluator internals continue to evolve toward exact server
+// parity.
+package conditional

--- a/docs/plans/buildkite-conditionals-package-migration.md
+++ b/docs/plans/buildkite-conditionals-package-migration.md
@@ -1,0 +1,32 @@
+---
+status: proposed
+last_reviewed: 2026-06-06
+related_plans:
+  - docs/plans/buildkite-conditionals-parity.md
+---
+
+# Conditional Package Migration
+
+The supported public API is the root package:
+
+```go
+import "github.com/buildkite/conditional"
+```
+
+The existing implementation packages remain available during the transition, but
+they are not the final parity contract. Once the root API can evaluate the
+server grammar directly, move implementation packages under `internal/`.
+
+| Current package | Final home | Notes |
+| --- | --- | --- |
+| `ast` | `internal/ast` | Syntax model for the server grammar. |
+| `lexer` | `internal/lexer` | Tokenizer for the server grammar. |
+| `parser` | `internal/parser` | Parser plus source positions. |
+| `evaluator` | `internal/evaluator` | Type-checked evaluator internals. |
+| `object` | `internal/object` or replaced | Runtime values and type information. |
+| `token` | `internal/token` | Parser implementation detail. |
+| `repl` | `internal/repl` or removed | CLI/debugging helper, not library API. |
+| `cmd/conditional` | `cmd/conditional` | CLI can depend on the root API. |
+
+Do not add new external callers to implementation packages while the parity work
+is in progress.

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -221,6 +221,7 @@ type Actor struct {
 
 type Pipeline struct {
 	ID                      *string
+	Name                    *string
 	Slug                    *string
 	DefaultBranch           *string
 	Repository              *string

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -392,8 +392,8 @@ from this plan.
 
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
-| Dotted names | Local parsing/evaluation leans on nested object lookup. It cannot exactly model server identifiers that are both scalar and namespace-like, such as `build.pull_request.repository` and `build.pull_request.repository.fork`. | Match the server grammar's flat dotted identifiers for variables and functions. |
-| `build.env()` | Only top-level calls evaluate cleanly. `build.env("NAME")` currently fails during evaluation. | Treat `build.env` as a flat function identifier with server-compatible nullable return behavior. |
+| Dotted names | The root adapter supplies flat assignment keys for server variables, but parser/evaluator internals still keep the older nested-object fallback. | Match the server grammar's flat dotted identifiers throughout parser, type checker, and evaluator internals. |
+| `build.env()` | The root adapter supports `build.env("NAME")` as a flat function identifier, but full validator coverage still belongs in the conformance slices. | Treat `build.env` as a flat function identifier with server-compatible nullable return behavior across validation and conformance tests. |
 | Ternary syntax | Not implemented. | Implement server ternary `condition ? true_value : false_value` precedence and type checking. |
 | Shell substitution | Not implemented. | Implement server grammar for `$name`, `${name}`, default/alternate/error forms, and substring forms. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: active
 last_reviewed: 2026-06-06
 spec_refs:
   - https://buildkite.com/docs/pipelines/configure/conditionals
@@ -266,10 +266,13 @@ type Step struct {
 }
 ```
 
-Fields such as visible teams and preferred emails are caller-supplied
-database-backed facts. Pure conditional values are derived in-library when the
-server does so, such as `build.source_event` from `Build.SourceEvent` or
-`BUILDKITE_GITHUB_EVENT` when `Build.Source == "webhook"`.
+Fields such as visible teams and organization-preferred creator emails are
+caller-supplied database-backed facts. Preferred creator email resolution should
+populate `Actor.Email`, matching the server's `build.creator.email` assignment
+rather than inventing a separate conditional variable. Pure conditional values
+are derived in-library when the server does so, such as `build.source_event`
+from `Build.SourceEvent` or `BUILDKITE_GITHUB_EVENT` when
+`Build.Source == "webhook"`.
 
 Environment merge behavior is part of the public contract:
 
@@ -337,17 +340,17 @@ upstream group is accounted for.
 
 Initial manifest:
 
-| Upstream source | Groups to account for | Required status before parity claim |
-| --- | --- | --- |
-| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `ported` |
-| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `ported` or `superseded` by Go type/context tests |
-| `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `ported` |
-| `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `ported` |
-| `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `ported` |
-| `spec/models/step/notification_spec.rb` | step variables and false-on-error notification behavior | `ported` |
-| `spec/models/build/pipeline_config/build_notifications_spec.rb` | config parsing and notification conditional propagation | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
-| `spec/models/build/pipeline_config/step_notifications_spec.rb` | config parsing and step notification conditional propagation | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
+| Upstream source | Groups to account for | Current status | Required status before parity claim |
+| --- | --- | --- | --- |
+| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: parser grammar parity is Slice 3 | `ported` or `intentionally_excluded` with reason |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: evaluator parity is Slice 4 | `ported` |
+| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: typed context model is Slice 4 and Slice 5 | `ported` or `superseded` by Go type/context tests |
+| `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Buildkite context semantics are Slice 5 | `ported` |
+| `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: root smoke tests cover only blank validation in Slice 1 | `ported` |
+| `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `blocked`: root smoke tests cover only false-on-error in Slice 1 | `ported` |
+| `spec/models/step/notification_spec.rb` | step variables and false-on-error notification behavior | `blocked`: root smoke tests cover only step availability in Slice 1 | `ported` |
+| `spec/models/build/pipeline_config/build_notifications_spec.rb` | config parsing and notification conditional propagation | `blocked`: config parsing is not in the current slice | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
+| `spec/models/build/pipeline_config/step_notifications_spec.rb` | config parsing and step notification conditional propagation | `blocked`: config parsing is not in the current slice | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
 
 The manifest can live in this plan while work is small. If it becomes too large,
 move it to `docs/plans/buildkite-conditionals-upstream-manifest.md` and link it
@@ -376,11 +379,20 @@ from this plan.
 - Some landed behavior is now explicitly provisional because it diverges from
   the server grammar or server regex validator.
 
+### Active Slice
+
+- Slice 1 is creating the root package API, server-derived entrypoint model,
+  public context structs, typed error categories, root smoke tests, and package
+  migration map.
+- `docs/plans/buildkite-conditionals-package-migration.md` records the intended
+  movement from public implementation packages to `internal/` once the root API
+  is ready to own the parity contract.
+
 ### Known Gaps
 
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
-| Dotted names | Local parsing/evaluation leans on nested object lookup. | Match the server grammar's flat dotted identifiers for variables and functions. |
+| Dotted names | Local parsing/evaluation leans on nested object lookup. It cannot exactly model server identifiers that are both scalar and namespace-like, such as `build.pull_request.repository` and `build.pull_request.repository.fork`. | Match the server grammar's flat dotted identifiers for variables and functions. |
 | `build.env()` | Only top-level calls evaluate cleanly. `build.env("NAME")` currently fails during evaluation. | Treat `build.env` as a flat function identifier with server-compatible nullable return behavior. |
 | Ternary syntax | Not implemented. | Implement server ternary `condition ? true_value : false_value` precedence and type checking. |
 | Shell substitution | Not implemented. | Implement server grammar for `$name`, `${name}`, default/alternate/error forms, and substring forms. |

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,51 @@
+package conditional
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorKind classifies conditional failures without depending on exact server
+// error text.
+type ErrorKind string
+
+const (
+	// ErrorKindParse indicates that the expression could not be parsed.
+	ErrorKindParse ErrorKind = "parse"
+	// ErrorKindValidation indicates that validation failed before evaluation.
+	ErrorKindValidation ErrorKind = "validation"
+	// ErrorKindEvaluation indicates that evaluation failed.
+	ErrorKindEvaluation ErrorKind = "evaluation"
+	// ErrorKindResult indicates that the expression did not evaluate to a bool.
+	ErrorKindResult ErrorKind = "result"
+)
+
+// Error is a typed conditional error.
+type Error struct {
+	Kind    ErrorKind
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string {
+	if e.Message == "" {
+		return string(e.Kind)
+	}
+	return fmt.Sprintf("%s: %s", e.Kind, e.Message)
+}
+
+// Unwrap returns the underlying cause, if any.
+func (e *Error) Unwrap() error {
+	return e.Cause
+}
+
+// Is reports whether err has the same error kind as target.
+func (e *Error) Is(target error) bool {
+	targetError, ok := target.(*Error)
+	return ok && e.Kind == targetError.Kind
+}
+
+// IsErrorKind reports whether err contains a conditional Error with kind.
+func IsErrorKind(err error, kind ErrorKind) bool {
+	return errors.Is(err, &Error{Kind: kind})
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -47,6 +47,14 @@ func Eval(node ast.Node, scope Scope) object.Object {
 		return evalPrefixExpression(node.Operator, right)
 
 	case *ast.InfixExpression:
+		if node.Operator == "." {
+			if key, ok := dottedIdentifier(node); ok {
+				if obj, ok := scope.Get(key); ok {
+					return obj
+				}
+			}
+		}
+
 		left := Eval(node.Left, scope)
 		if isError(left) {
 			return left
@@ -97,6 +105,28 @@ func Eval(node ast.Node, scope Scope) object.Object {
 
 	default:
 		return newError("unhandled type: %T", node)
+	}
+}
+
+func dottedIdentifier(expr ast.Expression) (string, bool) {
+	switch expr := expr.(type) {
+	case *ast.Identifier:
+		return expr.Value, true
+	case *ast.InfixExpression:
+		if expr.Operator != "." {
+			return "", false
+		}
+		left, ok := dottedIdentifier(expr.Left)
+		if !ok {
+			return "", false
+		}
+		right, ok := expr.Right.(*ast.Identifier)
+		if !ok {
+			return "", false
+		}
+		return left + "." + right.Value, true
+	default:
+		return "", false
 	}
 }
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -222,12 +222,10 @@ func evalLogicalExpression(operator string, left object.Object, rightExp ast.Exp
 func evalBangOperatorExpression(right object.Object) object.Object {
 	// defer untrace(trace("evalBangOperatorExpression", right))
 
-	switch right {
-	case TRUE:
-		return FALSE
-	case FALSE:
-		return TRUE
-	case NULL:
+	switch right := right.(type) {
+	case *object.Boolean:
+		return nativeBoolToBooleanObject(!right.Value)
+	case *object.Null:
 		return TRUE
 	default:
 		return FALSE

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -20,8 +20,8 @@ const (
 	AND    // &&
 	EQUALS // ==
 	PREFIX // !X
-	DOT    // foo.bar
 	CALL   // myfunction(true)
+	DOT    // foo.bar
 )
 
 var precedences = map[token.TokenType]int{
@@ -310,16 +310,38 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
 	defer untrace(trace("parseCallExpression"))
 
-	ident, ok := function.(*ast.Identifier)
+	name, ok := functionName(function)
 	if !ok {
 		msg := fmt.Sprintf("function call must be an identifier, got %v", p.curToken.Type)
 		p.errors = append(p.errors, msg)
 		return nil
 	}
 
-	exp := &ast.CallExpression{Token: p.curToken, Function: ident.Value}
+	exp := &ast.CallExpression{Token: p.curToken, Function: name}
 	exp.Arguments = p.parseExpressionList(token.RPAREN)
 	return exp
+}
+
+func functionName(function ast.Expression) (string, bool) {
+	switch function := function.(type) {
+	case *ast.Identifier:
+		return function.Value, true
+	case *ast.InfixExpression:
+		if function.Operator != token.DOT {
+			return "", false
+		}
+		left, ok := functionName(function.Left)
+		if !ok {
+			return "", false
+		}
+		right, ok := function.Right.(*ast.Identifier)
+		if !ok {
+			return "", false
+		}
+		return left + "." + right.Value, true
+	default:
+		return "", false
+	}
 }
 
 func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {


### PR DESCRIPTION
The parity work needs a root package contract before the conformance suite grows around the wrong shape. Right now callers still have to think in terms of parser, evaluator, and object internals instead of Buildkite's server-side conditional entrypoints.

This adds the root `conditional` API with public `Context` data, server-derived `EntryPoint` values, and typed error categories. `Evaluate` now returns a boolean result, reports parser/evaluation/non-boolean failures through typed errors, and mirrors notification deliverability by returning `false` when conditional evaluation fails in notification paths.

For example, later parity tests can now target the public package directly:

```go
got, err := conditional.Evaluate(`build.branch =~ /^features\//`, conditional.Context{
    EntryPoint: conditional.EntryPointBuildCondition,
    Build: conditional.Build{Branch: &branch},
})
```

The slice also records the package migration map for moving implementation packages under `internal/`, marks the parity plan active, and adds explicit upstream spec manifest statuses so follow-up slices do not overclaim server parity.
