### PR TITLE
test: Add conditional conformance tables

### DIFF
--- a/conditional_test.go
+++ b/conditional_test.go
@@ -1,345 +1,73 @@
 package conditional
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestEvaluateBuildCondition(t *testing.T) {
-	branch := "features/api"
-
-	got, err := Evaluate(`build.branch =~ /^features\//`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build:      Build{Branch: &branch},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluateDefaultsToBuildCondition(t *testing.T) {
-	branch := "features/api"
-
-	got, err := Evaluate(`build.branch == "features/api"`, Context{
-		Build: Build{Branch: &branch},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluateRejectsUnknownEntryPoint(t *testing.T) {
-	_, err := Evaluate(`true`, Context{EntryPoint: "unknown"})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
-	}
-}
-
-func TestEvaluateMergesProjectEnvBeforeBuildEnv(t *testing.T) {
-	got, err := Evaluate(`env("DEPLOY_ENV") == "build" && env("EMPTY") == "" && env("MISSING") == ""`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		ProjectEnv: map[string]string{
-			"DEPLOY_ENV": "project",
-			"EMPTY":      "",
+func TestRootValidateAndEvaluateErrorKinds(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "parse error",
+			source:     upstreamBuildConditionSpec,
+			expression: `nope != == one`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindParse,
 		},
-		BuildEnv: map[string]string{
-			"DEPLOY_ENV": "build",
+		{
+			name:       "evaluation error",
+			source:     upstreamBuildConditionSpec,
+			expression: `unknown.value == "x"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindEvaluation,
 		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluateBuildEnvReturnsNullForMissingVariables(t *testing.T) {
-	got, err := Evaluate(`build.env("PROJECTED") == "fully" && build.env("EMPTY") == "" && build.env("MISSING") == null`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		ProjectEnv: map[string]string{
-			"PROJECTED": "fully",
+		{
+			name:       "result error",
+			source:     upstreamBuildValidatorSpec,
+			expression: `"not boolean"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindResult,
 		},
-		BuildEnv: map[string]string{
-			"EMPTY": "",
+		{
+			name:       "validation error",
+			source:     upstreamBuildValidatorSpec,
+			expression: `step.key == "deploy"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindValidation,
 		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
 	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
+
+	runEvaluateCases(t, tests)
 }
 
-func TestEvaluateDerivesSupportedBuildkiteEnv(t *testing.T) {
-	branch := "main"
-	tag := "v1.2.3"
-	message := "ship it"
-	commit := "abc123"
-	pipelineName := "Deploy"
-	pipelineSlug := "deploy"
-	pipelineID := "018f"
-	repository := "git@github.com:acme/repo.git"
-	organizationSlug := "acme"
-	pullRequestID := "123"
-	pullRequestBaseBranch := "main"
-	mergeQueueBaseBranch := "main"
-	mergeQueueBaseCommit := "def456"
-
-	got, err := Evaluate(`build.env("BUILDKITE_BRANCH") == "main" &&
-		build.env("BUILDKITE_TAG") == "v1.2.3" &&
-		env("BUILDKITE_MESSAGE") == "ship it" &&
-		build.env("BUILDKITE_COMMIT") == "abc123" &&
-		build.env("BUILDKITE_PIPELINE_NAME") == "Deploy" &&
-		build.env("BUILDKITE_PIPELINE_SLUG") == "deploy" &&
-		build.env("BUILDKITE_PIPELINE_ID") == "018f" &&
-		build.env("BUILDKITE_REPO") == "git@github.com:acme/repo.git" &&
-		build.env("BUILDKITE_ORGANIZATION_SLUG") == "acme" &&
-		build.env("BUILDKITE_PULL_REQUEST") == "123" &&
-		build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") == "main" &&
-		build.env("BUILDKITE_PULL_REQUEST_REPO") == "git@github.com:acme/repo.git" &&
-		build.env("BUILDKITE_PULL_REQUEST_LABELS") == "bug,deploy" &&
-		build.env("BUILDKITE_MERGE_QUEUE_BASE_BRANCH") == "main" &&
-		build.env("BUILDKITE_MERGE_QUEUE_BASE_COMMIT") == "def456"`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build: Build{
-			Branch:      &branch,
-			Tag:         &tag,
-			Message:     &message,
-			Commit:      &commit,
-			PullRequest: PullRequest{ID: &pullRequestID, BaseBranch: &pullRequestBaseBranch, Repository: &repository, Labels: []string{"bug", "deploy"}},
-			MergeQueue:  MergeQueue{BaseBranch: &mergeQueueBaseBranch, BaseCommit: &mergeQueueBaseCommit},
+func TestRootValidateErrorKinds(t *testing.T) {
+	tests := []validateCase{
+		{
+			name:       "parse error",
+			source:     upstreamBuildConditionSpec,
+			expression: `nope != == one`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindParse,
 		},
-		Pipeline:     Pipeline{Name: &pipelineName, Slug: &pipelineSlug, ID: &pipelineID, Repository: &repository},
-		Organization: Organization{Slug: &organizationSlug},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluateFiltersUnsupportedBuildkiteEnv(t *testing.T) {
-	_, err := Evaluate(`build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`, Context{
-		EntryPoint: EntryPointBuildCondition,
-	})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
-	}
-
-	got, err := Evaluate(`build.env(env("SECRET_NAME")) == null && env(env("SECRET_NAME")) == ""`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		BuildEnv: map[string]string{
-			"SECRET_NAME":                  "BUILDKITE_AGENT_ACCESS_TOKEN",
-			"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
+		{
+			name:       "evaluation error",
+			source:     upstreamBuildConditionSpec,
+			expression: `unknown.value == "x"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindEvaluation,
 		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluatePullRequestRepositoryAndFork(t *testing.T) {
-	repository := "git@github.com:acme/repo.git"
-	fork := true
-
-	got, err := Evaluate(`build.pull_request.repository == "git@github.com:acme/repo.git" && build.pull_request.repository.fork`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build: Build{
-			PullRequest: PullRequest{
-				Repository:     &repository,
-				RepositoryFork: &fork,
-			},
+		{
+			name:       "result error",
+			source:     upstreamBuildValidatorSpec,
+			expression: `"not boolean"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindResult,
 		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluatePullRequestLabelRequiresLabelAction(t *testing.T) {
-	source := "webhook"
-	event := "pull_request"
-	label := "test-gpu"
-	opened := "opened"
-	labeled := "labeled"
-
-	got, err := Evaluate(`build.pull_request.label == null`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build: Build{
-			Source:       &source,
-			SourceEvent:  &event,
-			SourceAction: &opened,
-			PullRequest:  PullRequest{Label: &label},
+		{
+			name:       "validation error",
+			source:     upstreamBuildValidatorSpec,
+			expression: `step.key == "deploy"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindValidation,
 		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
 	}
 
-	got, err = Evaluate(`build.pull_request.label == "test-gpu"`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build: Build{
-			Source:       &source,
-			SourceEvent:  &event,
-			SourceAction: &labeled,
-			PullRequest:  PullRequest{Label: &label},
-		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestEvaluateReturnsParseError(t *testing.T) {
-	_, err := Evaluate(`nope != == one`, Context{EntryPoint: EntryPointBuildCondition})
-	if !IsErrorKind(err, ErrorKindParse) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindParse)
-	}
-}
-
-func TestEvaluateReturnsResultErrorForNonBoolean(t *testing.T) {
-	_, err := Evaluate(`"not boolean"`, Context{EntryPoint: EntryPointBuildCondition})
-	if !IsErrorKind(err, ErrorKindResult) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindResult)
-	}
-}
-
-func TestNotificationEntryPointFailsClosed(t *testing.T) {
-	got, err := Evaluate(`nope != == one`, Context{EntryPoint: EntryPointBuildNotification})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if got {
-		t.Fatalf("Evaluate returned true, want false")
-	}
-
-	got, err = Evaluate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildNotification})
-	if err != nil {
-		t.Fatalf("Evaluate returned error for unavailable step variable: %v", err)
-	}
-	if got {
-		t.Fatalf("Evaluate returned true for unavailable step variable, want false")
-	}
-}
-
-func TestNotificationEntryPointAllowsBlankCondition(t *testing.T) {
-	got, err := Evaluate(` `, Context{EntryPoint: EntryPointBuildNotification})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestValidateAcceptsBlank(t *testing.T) {
-	if err := Validate("   ", Context{EntryPoint: EntryPointBuildCondition}); err != nil {
-		t.Fatalf("Validate returned error: %v", err)
-	}
-}
-
-func TestValidateRejectsNonBooleanResult(t *testing.T) {
-	err := Validate(`"not boolean"`, Context{EntryPoint: EntryPointBuildCondition})
-	if !IsErrorKind(err, ErrorKindResult) {
-		t.Fatalf("Validate error = %v, want %s", err, ErrorKindResult)
-	}
-}
-
-func TestValidateRejectsMalformedEnvCalls(t *testing.T) {
-	tests := []string{
-		`env() == ""`,
-		`build.env("FOO", "BAR") == null`,
-	}
-
-	for _, expression := range tests {
-		err := Validate(expression, Context{EntryPoint: EntryPointBuildCondition})
-		if !IsErrorKind(err, ErrorKindValidation) {
-			t.Fatalf("Validate(%q) error = %v, want %s", expression, err, ErrorKindValidation)
-		}
-	}
-}
-
-func TestValidateRejectsNonServerOperators(t *testing.T) {
-	branch := "main"
-
-	err := Validate(`["main"] @> build.branch`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build:      Build{Branch: &branch},
-	})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
-	}
-
-	_, err = Evaluate(`["main"] @> build.branch`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Build:      Build{Branch: &branch},
-	})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
-	}
-}
-
-func TestPipelineTransitionFieldsFollowServerAssignmentTable(t *testing.T) {
-	startedPassing := true
-	startedFailing := false
-
-	got, err := Evaluate(`pipeline.started_passing && !pipeline.started_failing`, Context{
-		EntryPoint: EntryPointBuildCondition,
-		Pipeline: Pipeline{
-			StartedPassing: &startedPassing,
-			StartedFailing: &startedFailing,
-		},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-}
-
-func TestStepAvailabilityFollowsEntryPoint(t *testing.T) {
-	key := "deploy"
-
-	got, err := Evaluate(`step.key == "deploy"`, Context{
-		EntryPoint: EntryPointBuildConditionWithStep,
-		Step:       &Step{Key: &key},
-	})
-	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
-	}
-	if !got {
-		t.Fatalf("Evaluate returned false, want true")
-	}
-
-	err = Validate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildCondition})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
-	}
-
-	_, err = Evaluate(`step.key == "deploy"`, Context{EntryPoint: EntryPointBuildCondition})
-	if !IsErrorKind(err, ErrorKindValidation) {
-		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindValidation)
-	}
+	runValidateCases(t, tests)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,496 @@
+package conditional
+
+import "testing"
+
+func TestBuildkiteDocsExamples(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "branch is main or production",
+			source:     docsConditionalsSource,
+			expression: `build.branch == "main" || build.branch == "production"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("main")},
+			},
+			want: true,
+		},
+		{
+			name:       "branch is not production",
+			source:     docsConditionalsSource,
+			expression: `build.branch != "production"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("main")},
+			},
+			want: true,
+		},
+		{
+			name:       "building a tag",
+			source:     docsConditionalsSource,
+			expression: `build.tag != null`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Tag: str("v1.2.3")},
+			},
+			want: true,
+		},
+		{
+			name:       "build was created from schedule",
+			source:     docsConditionalsSource,
+			expression: `build.source == "schedule"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Source: str("schedule")},
+			},
+			want: true,
+		},
+		{
+			name:       "custom build env matches",
+			source:     docsConditionalsSource,
+			expression: `build.env("CUSTOM_ENVIRONMENT_VARIABLE") == "value"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv:   map[string]string{"CUSTOM_ENVIRONMENT_VARIABLE": "value"},
+			},
+			want: true,
+		},
+		{
+			name:       "creator teams includes deploy",
+			source:     docsConditionalsSource,
+			expression: `build.creator.teams includes "deploy"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					Creator: Actor{Teams: []string{"deploy", "platform"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "non draft pull request",
+			source:     docsConditionalsSource,
+			expression: `!build.pull_request.draft`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					PullRequest: PullRequest{Draft: boolptr(false)},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "merge queue targets main",
+			source:     docsConditionalsSource,
+			expression: `build.merge_queue.base_branch == "main"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					MergeQueue: MergeQueue{BaseBranch: str("main")},
+				},
+			},
+			want: true,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestBuildkiteContextAssignments(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "organization slug",
+			source:     upstreamBuildConditionSpec,
+			expression: `organization.slug == "org-slug-town"`,
+			ctx: Context{
+				EntryPoint:   EntryPointBuildCondition,
+				Organization: Organization{Slug: str("org-slug-town")},
+			},
+			want: true,
+		},
+		{
+			name:       "pipeline slug",
+			source:     upstreamBuildConditionSpec,
+			expression: `pipeline.slug == "slug-town"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Pipeline:   Pipeline{Slug: str("slug-town")},
+			},
+			want: true,
+		},
+		{
+			name:       "build source event from webhook env",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.source_event == "pull_request"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Source: str("webhook")},
+				BuildEnv:   map[string]string{"BUILDKITE_GITHUB_EVENT": "pull_request"},
+			},
+			want: true,
+		},
+		{
+			name:       "build source event null for non webhook",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.source_event == null`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Source: str("api")},
+				BuildEnv:   map[string]string{"BUILDKITE_GITHUB_EVENT": "pull_request"},
+			},
+			want: true,
+		},
+		{
+			name:       "build source action from webhook env",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.source_action == "labeled"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Source: str("webhook")},
+				BuildEnv:   map[string]string{"BUILDKITE_GITHUB_ACTION": "labeled"},
+			},
+			want: true,
+		},
+		{
+			name:       "pull request label only for labeled event",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.pull_request.label == "test-gpu"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					Source:       str("webhook"),
+					SourceEvent:  str("pull_request"),
+					SourceAction: str("labeled"),
+					PullRequest:  PullRequest{Label: str("test-gpu")},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "pull request label null for opened event",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.pull_request.label == null`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					Source:       str("webhook"),
+					SourceEvent:  str("pull_request"),
+					SourceAction: str("opened"),
+					PullRequest:  PullRequest{Label: str("test-gpu")},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "pull request repository and fork",
+			source:     docsConditionalsSource,
+			expression: `build.pull_request.repository == "git@github.com:acme/repo.git" && build.pull_request.repository.fork`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					PullRequest: PullRequest{
+						Repository:     str("git@github.com:acme/repo.git"),
+						RepositoryFork: boolptr(true),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "build fixed",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.fixed`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Fixed: boolptr(true)},
+			},
+			want: true,
+		},
+		{
+			name:       "pipeline started passing",
+			source:     upstreamBuildConditionSpec,
+			expression: `pipeline.started_passing && !pipeline.started_failing`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Pipeline: Pipeline{
+					StartedPassing: boolptr(true),
+					StartedFailing: boolptr(false),
+				},
+			},
+			want: true,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestBuildkiteEnvironmentFunctions(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "env sees build env override",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("DEPLOY_ENV") == "build"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				ProjectEnv: map[string]string{
+					"DEPLOY_ENV": "project",
+				},
+				BuildEnv: map[string]string{
+					"DEPLOY_ENV": "build",
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "env returns empty string for missing values",
+			source:     upstreamBuildNotificationSpec,
+			expression: `env("MISSING") == ""`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			want:       true,
+		},
+		{
+			name:       "build env returns null for missing values",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("MISSING") == null`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			want:       true,
+		},
+		{
+			name:       "build env reads project env",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("PROJECTED") == "fully"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				ProjectEnv: map[string]string{
+					"PROJECTED": "fully",
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "build env preserves present empty string",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("EMPTY") == ""`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv:   map[string]string{"EMPTY": ""},
+			},
+			want: true,
+		},
+		{
+			name:       "built in tag becomes empty string for env",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("BUILDKITE_TAG") == ""`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			want:       true,
+		},
+		{
+			name:       "built in pull request defaults false",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("BUILDKITE_PULL_REQUEST") == "false"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			want:       true,
+		},
+		{
+			name:       "supported conditional only Buildkite env is exposed",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("BUILDKITE_GITHUB_REVIEW_STATE") == "approved" && build.env("BUILDKITE_GITHUB_REVIEW_STATE") == "approved"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv:   map[string]string{"BUILDKITE_GITHUB_REVIEW_STATE": "approved"},
+			},
+			want: true,
+		},
+		{
+			name:   "built in Buildkite env values are derived from context",
+			source: upstreamBuildConditionSpec,
+			expression: `build.env("BUILDKITE_BRANCH") == "main" &&
+				build.env("BUILDKITE_TAG") == "v1.2.3" &&
+				env("BUILDKITE_MESSAGE") == "ship it" &&
+				build.env("BUILDKITE_COMMIT") == "abc123" &&
+				build.env("BUILDKITE_PIPELINE_NAME") == "Deploy" &&
+				build.env("BUILDKITE_PIPELINE_SLUG") == "deploy" &&
+				build.env("BUILDKITE_PIPELINE_ID") == "018f" &&
+				build.env("BUILDKITE_REPO") == "git@github.com:acme/repo.git" &&
+				build.env("BUILDKITE_ORGANIZATION_SLUG") == "acme" &&
+				build.env("BUILDKITE_PULL_REQUEST") == "123" &&
+				build.env("BUILDKITE_PULL_REQUEST_BASE_BRANCH") == "main" &&
+				build.env("BUILDKITE_PULL_REQUEST_REPO") == "git@github.com:acme/repo.git" &&
+				build.env("BUILDKITE_PULL_REQUEST_LABELS") == "bug,deploy" &&
+				build.env("BUILDKITE_MERGE_QUEUE_BASE_BRANCH") == "main" &&
+				build.env("BUILDKITE_MERGE_QUEUE_BASE_COMMIT") == "def456"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build: Build{
+					Branch:  str("main"),
+					Tag:     str("v1.2.3"),
+					Message: str("ship it"),
+					Commit:  str("abc123"),
+					PullRequest: PullRequest{
+						ID:         str("123"),
+						BaseBranch: str("main"),
+						Repository: str("git@github.com:acme/repo.git"),
+						Labels:     []string{"bug", "deploy"},
+					},
+					MergeQueue: MergeQueue{
+						BaseBranch: str("main"),
+						BaseCommit: str("def456"),
+					},
+				},
+				Pipeline: Pipeline{
+					Name:       str("Deploy"),
+					Slug:       str("deploy"),
+					ID:         str("018f"),
+					Repository: str("git@github.com:acme/repo.git"),
+				},
+				Organization: Organization{Slug: str("acme")},
+			},
+			want: true,
+		},
+		{
+			name:       "unsupported Buildkite env is filtered when indirect",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env(env("SECRET_NAME")) == null && env(env("SECRET_NAME")) == ""`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv: map[string]string{
+					"SECRET_NAME":                  "BUILDKITE_AGENT_ACCESS_TOKEN",
+					"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
+				},
+			},
+			want: true,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestBuildkiteContextValidation(t *testing.T) {
+	tests := []validateCase{
+		{
+			name:       "blank condition is valid",
+			source:     upstreamBuildValidatorSpec,
+			expression: "   ",
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+		},
+		{
+			name:       "invalid conditional is rejected",
+			source:     upstreamBuildValidatorSpec,
+			expression: "lol",
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "step variables rejected without step option",
+			source:     upstreamBuildValidatorSpec,
+			expression: `step.outcome == "hard_failed"`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "step variables accepted with step option",
+			source:     upstreamBuildValidatorSpec,
+			expression: `step.outcome == "hard_failed"`,
+			ctx:        Context{EntryPoint: EntryPointBuildConditionWithStep},
+		},
+		{
+			name:       "literal unsupported Buildkite env is rejected",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindValidation,
+		},
+	}
+
+	runValidateCases(t, tests)
+}
+
+func TestBuildkiteEntrypoints(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "evaluate defaults to build condition",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.branch == "features/api"`,
+			ctx: Context{
+				Build: Build{Branch: str("features/api")},
+			},
+			want: true,
+		},
+		{
+			name:       "unknown entrypoint rejects evaluation",
+			source:     upstreamBuildConditionSpec,
+			expression: `true`,
+			ctx:        Context{EntryPoint: "unknown"},
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "build notification blank condition is deliverable",
+			source:     upstreamBuildNotificationSpec,
+			expression: ` `,
+			ctx:        Context{EntryPoint: EntryPointBuildNotification},
+			want:       true,
+		},
+		{
+			name:       "build notification false when condition fails",
+			source:     upstreamBuildNotificationSpec,
+			expression: `env("BUILDKITE_BRANCH") == "not-the-one"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildNotification,
+				Build:      Build{Branch: str("main")},
+			},
+			want: false,
+		},
+		{
+			name:       "build notification false when unparseable",
+			source:     upstreamBuildNotificationSpec,
+			expression: `nope != == one`,
+			ctx:        Context{EntryPoint: EntryPointBuildNotification},
+			want:       false,
+		},
+		{
+			name:       "build notification false when step variable unavailable",
+			source:     upstreamBuildNotificationSpec,
+			expression: `step.key == "deploy"`,
+			ctx:        Context{EntryPoint: EntryPointBuildNotification},
+			want:       false,
+		},
+		{
+			name:       "step notification can use step variables",
+			source:     upstreamStepNotificationSpec,
+			expression: `step.key == "foo"`,
+			ctx: Context{
+				EntryPoint: EntryPointStepNotification,
+				Step:       &Step{Key: str("foo")},
+			},
+			want: true,
+		},
+		{
+			name:       "build condition with step can use step variables",
+			source:     upstreamBuildConditionSpec,
+			expression: `step.key == "deploy"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildConditionWithStep,
+				Step:       &Step{Key: str("deploy")},
+			},
+			want: true,
+		},
+		{
+			name:       "step notification false when step condition fails",
+			source:     upstreamStepNotificationSpec,
+			expression: `step.id == "not-a-uuid"`,
+			ctx: Context{
+				EntryPoint: EntryPointStepNotification,
+				Step:       &Step{ID: str("uuid")},
+			},
+			want: false,
+		},
+		{
+			name:       "step notification false when unparseable",
+			source:     upstreamStepNotificationSpec,
+			expression: `nope != == one`,
+			ctx:        Context{EntryPoint: EntryPointStepNotification},
+			want:       false,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -343,13 +343,13 @@ Initial manifest:
 
 | Upstream source | Groups to account for | Current status | Required status before parity claim |
 | --- | --- | --- | --- |
-| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: parser grammar parity is Slice 3 | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: evaluator parity is Slice 4 | `ported` |
+| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 2 seeds source-tagged root cases for comments, simple expressions, precedence, and local rejection of `@>`; full parser grammar parity is Slice 3 | `ported` or `intentionally_excluded` with reason |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 2 seeds source-tagged root cases for booleans, null comparisons, string comparisons, array string includes, regexes, and short-circuiting; ternaries, shell substitutions, enum behavior, null-regex semantics, and array-regex includes remain Slice 4 work | `ported` |
 | `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: typed context model is Slice 4 and Slice 5 | `ported` or `superseded` by Go type/context tests |
-| `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Buildkite context semantics are Slice 5 | `ported` |
-| `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: root smoke tests cover only blank validation in Slice 1 | `ported` |
-| `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `blocked`: root smoke tests cover only false-on-error in Slice 1 | `ported` |
-| `spec/models/step/notification_spec.rb` | step variables and false-on-error notification behavior | `blocked`: root smoke tests cover only step availability in Slice 1 | `ported` |
+| `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Slice 2 seeds source-tagged root cases for representative `env()`, `build.env()`, organization, pipeline, webhook, pull request label, project env merge, and validation behavior; the exhaustive context matrix is Slice 5 | `ported` |
+| `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: Slice 2 ports blank string, invalid expression, step-variable rejection, and step-option acceptance through root validation; nil validation is not representable in the string API | `ported` or `intentionally_excluded` with reason |
+| `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `blocked`: Slice 2 ports blank/no-condition equivalent, false-on-unmet condition, false-on-parse-error, and false-on-unavailable-step-variable behavior; full notification parsing/config propagation remains out of scope | `ported` |
+| `spec/models/step/notification_spec.rb` | step variables and false-on-error notification behavior | `blocked`: Slice 2 ports step key/id checks and false-on-parse-error through the step notification entrypoint; full step notification model behavior remains out of scope | `ported` |
 | `spec/models/build/pipeline_config/build_notifications_spec.rb` | config parsing and notification conditional propagation | `blocked`: config parsing is not in the current slice | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
 | `spec/models/build/pipeline_config/step_notifications_spec.rb` | config parsing and step notification conditional propagation | `blocked`: config parsing is not in the current slice | `blocked` until config parsing is in scope, or `intentionally_excluded` with reason |
 
@@ -382,9 +382,18 @@ from this plan.
 
 ### Active Slice
 
-- Slice 1 is creating the root package API, server-derived entrypoint model,
+- Slice 2 is creating the source-tagged, table-driven root conformance suite.
+  The suite keeps test data in Go code and uses a small helper instead of YAML
+  fixtures.
+- Root package cases now carry a `source` string that points to the public docs
+  or the upstream `buildkite/buildkite` spec/model file that motivated the case.
+- Server-supported cases that the current implementation cannot pass are not
+  added as skipped tests. They remain recorded in the manifest and known gaps
+  until the parser, evaluator, context, and regex parity slices implement them.
+- Slice 1 introduced the root package API, server-derived entrypoint model,
   public context structs, typed error categories, root smoke tests, and package
-  migration map.
+  migration map. If it is not yet merged into `master`, Slice 2 stays stacked on
+  that branch.
 - `docs/plans/buildkite-conditionals-package-migration.md` records the intended
   movement from public implementation packages to `internal/` once the root API
   is ready to own the parity contract.
@@ -404,7 +413,7 @@ from this plan.
 | Regex syntax | regexp2 accepts some features the server rejects. | Keep regexp2 only with a server-compatible validator for flags and unsupported constructs. |
 | Divergent operators | `@>` exists locally but is not server syntax. | Remove it from the Buildkite language and tests. |
 | Type mismatch semantics | Local behavior exists but is not server-proven. | Build a server-derived matrix for equality, regex matching, `includes`, `!`, missing values, and function argument errors. |
-| Conformance | Unit tests cover selected docs examples. | Add idiomatic table-driven Go conformance tests that can be run locally and optionally compared with a server oracle. |
+| Conformance | Root package tests are now split into source-tagged table-driven files for syntax, evaluation, regex, context, and root API error behavior. The tables seed docs and upstream spec coverage but do not yet port every blocked upstream group. | Expand the tables in each implementation slice until every manifest group is `ported`, `superseded`, or `intentionally_excluded` before claiming parity. |
 
 ## Server Syntax And Context Surface To Cover
 
@@ -644,6 +653,30 @@ Definition of done:
 - Existing unit tests still run through `mise run check`.
 - The helper makes parser errors visible; tests must not evaluate a nil or
   erroneous AST by accident.
+
+Current Slice 2 progress:
+
+- `test_helpers_test.go` provides small pointer helpers and shared
+  `runEvaluateCases` / `runValidateCases` helpers that require every case to
+  name its source.
+- `syntax_test.go`, `eval_test.go`, `regex_test.go`, `context_test.go`, and
+  `conditional_test.go` split the root suite by behavior rather than by a large
+  monolithic fixture.
+- The docs operator reference is covered for comparators, logical operators,
+  `includes`, integers, strings, booleans, `null`, parentheses, regex literals,
+  prefix `!`, and comments.
+- The docs example expressions are seeded for branch equality/inequality,
+  feature branch regex, tag presence, tag regex via variable and `build.env()`,
+  case-insensitive message regex, scheduled source, custom env, creator teams,
+  draft pull requests, and merge queue base branch.
+- Docs examples that encode YAML/env-substitution escaping for `$` anchors are
+  recorded as blocked until Slice 3 implements shell-style substitution; the
+  current regex tests separately assert raw `$` anchors and escaped literal
+  dollars so the parser does not conflate those semantics.
+- Representative upstream cases are ported from parser, evaluator,
+  `Build::Condition`, build condition validator, build notification, and step
+  notification specs. The manifest remains `blocked` for every upstream group
+  that still needs feature work rather than skipped tests.
 
 ### Slice 3: Parser Grammar Parity
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -1,0 +1,114 @@
+package conditional
+
+import "testing"
+
+func TestConditionalEvaluationSemantics(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "true literal",
+			source:     upstreamEvaluatorSpec,
+			expression: `true`,
+			want:       true,
+		},
+		{
+			name:       "false literal",
+			source:     upstreamEvaluatorSpec,
+			expression: `false`,
+			want:       false,
+		},
+		{
+			name:       "integer equality",
+			source:     upstreamEvaluatorSpec,
+			expression: `1 == 1`,
+			want:       true,
+		},
+		{
+			name:       "integer inequality",
+			source:     upstreamEvaluatorSpec,
+			expression: `1 != 2`,
+			want:       true,
+		},
+		{
+			name:       "boolean null comparison",
+			source:     upstreamEvaluatorSpec,
+			expression: `true == null`,
+			want:       false,
+		},
+		{
+			name:       "null equality",
+			source:     upstreamEvaluatorSpec,
+			expression: `null == null`,
+			want:       true,
+		},
+		{
+			name:       "null inequality",
+			source:     upstreamEvaluatorSpec,
+			expression: `null != null`,
+			want:       false,
+		},
+		{
+			name:       "string equality",
+			source:     upstreamEvaluatorSpec,
+			expression: `env("branch") == "main"`,
+			ctx:        Context{BuildEnv: map[string]string{"branch": "main"}},
+			want:       true,
+		},
+		{
+			name:       "string inequality",
+			source:     upstreamEvaluatorSpec,
+			expression: `env("branch") != "production"`,
+			ctx:        Context{BuildEnv: map[string]string{"branch": "main"}},
+			want:       true,
+		},
+		{
+			name:       "array includes string",
+			source:     upstreamEvaluatorSpec,
+			expression: `["eggs", "ham", "coffee"] includes "ham"`,
+			want:       true,
+		},
+		{
+			name:       "array excludes string",
+			source:     upstreamEvaluatorSpec,
+			expression: `["eggs", "ham", "coffee"] includes "fruit"`,
+			want:       false,
+		},
+		{
+			name:       "logical and short-circuits false left side",
+			source:     upstreamEvaluatorSpec,
+			expression: `false && missing.value == "x"`,
+			want:       false,
+		},
+		{
+			name:       "logical or short-circuits true left side",
+			source:     upstreamEvaluatorSpec,
+			expression: `true || missing.value == "x"`,
+			want:       true,
+		},
+		{
+			name:       "nested precedence with and before or",
+			source:     upstreamParserSpec,
+			expression: `"a" == "d" || "a" == "b" && "a" == "a"`,
+			want:       false,
+		},
+		{
+			name:       "grouped precedence overrides and before or",
+			source:     upstreamParserSpec,
+			expression: `("a" == "d" || "a" == "b") && "a" == "a"`,
+			want:       false,
+		},
+		{
+			name:       "missing variable fails closed",
+			source:     upstreamBuildConditionSpec,
+			expression: `missing.value == "x"`,
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "non boolean result fails closed",
+			source:     upstreamBuildValidatorSpec,
+			expression: `"not boolean"`,
+			wantError:  ErrorKindResult,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}

--- a/regex_test.go
+++ b/regex_test.go
@@ -1,0 +1,107 @@
+package conditional
+
+import "testing"
+
+func TestConditionalRegexSemantics(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "branch starts with features slash",
+			source:     docsConditionalsSource,
+			expression: `build.branch =~ /^features\//`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("features/api")},
+			},
+			want: true,
+		},
+		{
+			name:       "raw dollar works as end anchor",
+			source:     upstreamEvaluatorSpec,
+			expression: `build.branch =~ /\/release-123$/`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("feature/release-123")},
+			},
+			want: true,
+		},
+		{
+			name:       "escaped dollar matches a literal dollar",
+			source:     upstreamEvaluatorSpec,
+			expression: `"fee$" =~ /fee\$/`,
+			want:       true,
+		},
+		{
+			name:       "escaped dollar does not act as anchor",
+			source:     upstreamEvaluatorSpec,
+			expression: `"fee" =~ /fee\$/`,
+			want:       false,
+		},
+		{
+			name:       "tag version expression",
+			source:     docsConditionalsSource,
+			expression: `build.tag =~ /^v[0-9]+\.0$/`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Tag: str("v1.0")},
+			},
+			want: true,
+		},
+		{
+			name:       "build env tag version expression",
+			source:     docsConditionalsSource,
+			expression: `build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.0$/`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Tag: str("v2.0")},
+			},
+			want: true,
+		},
+		{
+			name:       "case insensitive message exclusion",
+			source:     docsConditionalsSource,
+			expression: `build.message !~ /\[skip tests\]/i`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Message: str("run all tests")},
+			},
+			want: true,
+		},
+		{
+			name:       "case insensitive message match",
+			source:     upstreamEvaluatorSpec,
+			expression: `build.message =~ /\[skip tests\]/i`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Message: str("[SKIP TESTS] please")},
+			},
+			want: true,
+		},
+		{
+			name:       "posix digit class",
+			source:     upstreamEvaluatorSpec,
+			expression: `"v123" =~ /^v[[:digit:]]+$/`,
+			want:       true,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestConditionalRegexValidation(t *testing.T) {
+	tests := []validateCase{
+		{
+			name:       "unsupported flags fail during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"main" =~ /main/x`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "unterminated regex fails during parsing",
+			source:     upstreamParserSpec,
+			expression: `"main" =~ /main`,
+			wantError:  ErrorKindParse,
+		},
+	}
+
+	runValidateCases(t, tests)
+}

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -1,0 +1,147 @@
+package conditional
+
+import "testing"
+
+func TestConditionalSyntaxReference(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "equality comparator",
+			source:     docsConditionalsSource,
+			expression: `12345 == 12345`,
+			want:       true,
+		},
+		{
+			name:       "inequality comparator",
+			source:     docsConditionalsSource,
+			expression: `"feature-branch" != "main"`,
+			want:       true,
+		},
+		{
+			name:       "regex match comparator",
+			source:     docsConditionalsSource,
+			expression: `"v1.0" =~ /^v[0-9]+\.0$/`,
+			want:       true,
+		},
+		{
+			name:       "regex not match comparator",
+			source:     docsConditionalsSource,
+			expression: `"build all" !~ /skip tests/`,
+			want:       true,
+		},
+		{
+			name:       "logical operators respect precedence",
+			source:     docsConditionalsSource,
+			expression: `true || false && false`,
+			want:       true,
+		},
+		{
+			name:       "array includes operator",
+			source:     docsConditionalsSource,
+			expression: `["main", "production"] includes "production"`,
+			want:       true,
+		},
+		{
+			name:       "single and double quoted strings compare equally",
+			source:     docsConditionalsSource,
+			expression: `'feature-branch' == "feature-branch"`,
+			want:       true,
+		},
+		{
+			name:       "literals include true false and null",
+			source:     docsConditionalsSource,
+			expression: `true == true && false == false && null == null`,
+			want:       true,
+		},
+		{
+			name:       "parentheses change logical grouping",
+			source:     docsConditionalsSource,
+			expression: `(true || false) && false`,
+			want:       false,
+		},
+		{
+			name:       "prefix bang negates booleans",
+			source:     docsConditionalsSource,
+			expression: `!false`,
+			want:       true,
+		},
+		{
+			name:       "comments are ignored",
+			source:     docsConditionalsSource,
+			expression: "// ignored\ntrue && true\n// also ignored",
+			want:       true,
+		},
+		{
+			name:       "inline comments terminate expression text",
+			source:     upstreamParserSpec,
+			expression: "true // ignores comments on the same line",
+			want:       true,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestConditionalSyntaxErrors(t *testing.T) {
+	tests := []validateCase{
+		{
+			name:       "parse error for malformed comparator",
+			source:     upstreamParserSpec,
+			expression: `nope != == one`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "parse error for unsupported regexp flag",
+			source:     upstreamParserSpec,
+			expression: `"main" =~ /main/x`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "validation rejects local-only contains operator",
+			source:     upstreamParserSpec,
+			expression: `["main"] @> build.branch`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("main")},
+			},
+			wantError: ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects env without an argument",
+			source:     upstreamBuildConditionSpec,
+			expression: `env() == ""`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects build env with too many arguments",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("FOO", "BAR") == null`,
+			wantError:  ErrorKindValidation,
+		},
+	}
+
+	runValidateCases(t, tests)
+}
+
+func TestConditionalSyntaxEvaluationErrors(t *testing.T) {
+	tests := []evaluateCase{
+		{
+			name:       "evaluation rejects local-only contains operator",
+			source:     upstreamParserSpec,
+			expression: `["main"] @> build.branch`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("main")},
+			},
+			wantError: ErrorKindValidation,
+		},
+		{
+			name:       "evaluation rejects literal unsupported Buildkite env",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindValidation,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -1,0 +1,93 @@
+package conditional
+
+import "testing"
+
+const (
+	docsConditionalsSource = "https://buildkite.com/docs/pipelines/configure/conditionals"
+
+	upstreamParserSpec             = "buildkite/buildkite:spec/models/conditional/parser_spec.rb"
+	upstreamEvaluatorSpec          = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
+	upstreamBuildConditionSpec     = "buildkite/buildkite:spec/models/build/condition_spec.rb"
+	upstreamBuildValidatorSpec     = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
+	upstreamBuildNotificationSpec  = "buildkite/buildkite:spec/models/build/notification_spec.rb"
+	upstreamStepNotificationSpec   = "buildkite/buildkite:spec/models/step/notification_spec.rb"
+	upstreamConditionalRegexpModel = "buildkite/buildkite:app/models/conditional/regexp.rb"
+)
+
+type evaluateCase struct {
+	name       string
+	source     string
+	expression string
+	ctx        Context
+	want       bool
+	wantError  ErrorKind
+}
+
+type validateCase struct {
+	name       string
+	source     string
+	expression string
+	ctx        Context
+	wantError  ErrorKind
+}
+
+func runEvaluateCases(t *testing.T, tests []evaluateCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireCaseSource(t, tt.source)
+
+			got, err := Evaluate(tt.expression, tt.ctx)
+			if tt.wantError != "" {
+				if !IsErrorKind(err, tt.wantError) {
+					t.Fatalf("Evaluate(%q) error = %v, want %s", tt.expression, err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Evaluate(%q) returned error: %v", tt.expression, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Evaluate(%q) = %t, want %t", tt.expression, got, tt.want)
+			}
+		})
+	}
+}
+
+func runValidateCases(t *testing.T, tests []validateCase) {
+	t.Helper()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requireCaseSource(t, tt.source)
+
+			err := Validate(tt.expression, tt.ctx)
+			if tt.wantError != "" {
+				if !IsErrorKind(err, tt.wantError) {
+					t.Fatalf("Validate(%q) error = %v, want %s", tt.expression, err, tt.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate(%q) returned error: %v", tt.expression, err)
+			}
+		})
+	}
+}
+
+func requireCaseSource(t *testing.T, source string) {
+	t.Helper()
+
+	if source == "" {
+		t.Fatal("test case is missing source")
+	}
+}
+
+func str(value string) *string {
+	return &value
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}


### PR DESCRIPTION
The parity work needs a test shape that can grow with the server syntax instead of another pile of one-off smoke tests. This PR adds that root-package conformance structure before the next parser and evaluator slices, so future behavior changes have a clear place to land.

This is stacked on #13. It splits the root tests into syntax, evaluation, regex, context, and API error behavior tables, with a small helper that requires every case to name its docs or upstream `buildkite/buildkite` source. It also updates the parity plan manifest to record which upstream spec groups are seeded here and which remain blocked by missing implementation work.

The current tables cover docs operator examples, representative Buildkite context examples, notification false-on-error behavior, env/build.env behavior, and regression coverage from the root API slice.
