### PR TITLE
feat: Align parser grammar

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -80,6 +80,15 @@ func (r *Regexp) String() string {
 	return fmt.Sprintf("/%s/%s", r.Token.Literal, r.Flags)
 }
 
+type ShellExpansion struct {
+	Token token.Token
+	Raw   string
+}
+
+func (se *ShellExpansion) expressionNode()      {}
+func (se *ShellExpansion) TokenLiteral() string { return se.Token.Literal }
+func (se *ShellExpansion) String() string       { return se.Raw }
+
 type PrefixExpression struct {
 	Token    token.Token // The prefix token, e.g. !
 	Operator string
@@ -121,6 +130,29 @@ func (ie *InfixExpression) String() string {
 	}
 
 	out.WriteString(ie.Right.String())
+	out.WriteString(")")
+
+	return out.String()
+}
+
+type ConditionalExpression struct {
+	Token       token.Token
+	Condition   Expression
+	Consequence Expression
+	Alternative Expression
+}
+
+func (ce *ConditionalExpression) expressionNode()      {}
+func (ce *ConditionalExpression) TokenLiteral() string { return ce.Token.Literal }
+func (ce *ConditionalExpression) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	out.WriteString(ce.Condition.String())
+	out.WriteString(" ? ")
+	out.WriteString(ce.Consequence.String())
+	out.WriteString(" : ")
+	out.WriteString(ce.Alternative.String())
 	out.WriteString(")")
 
 	return out.String()

--- a/conditional.go
+++ b/conditional.go
@@ -124,6 +124,14 @@ func validateEnvCalls(expr ast.Expression) error {
 	switch expr := expr.(type) {
 	case *ast.PrefixExpression:
 		return validateEnvCalls(expr.Right)
+	case *ast.ConditionalExpression:
+		if err := validateEnvCalls(expr.Condition); err != nil {
+			return err
+		}
+		if err := validateEnvCalls(expr.Consequence); err != nil {
+			return err
+		}
+		return validateEnvCalls(expr.Alternative)
 	case *ast.InfixExpression:
 		if err := validateEnvCalls(expr.Left); err != nil {
 			return err
@@ -164,6 +172,14 @@ func validateOperators(expr ast.Expression) error {
 	switch expr := expr.(type) {
 	case *ast.PrefixExpression:
 		return validateOperators(expr.Right)
+	case *ast.ConditionalExpression:
+		if err := validateOperators(expr.Condition); err != nil {
+			return err
+		}
+		if err := validateOperators(expr.Consequence); err != nil {
+			return err
+		}
+		return validateOperators(expr.Alternative)
 	case *ast.InfixExpression:
 		if expr.Operator == "@>" {
 			return &Error{Kind: ErrorKindValidation, Message: "@> is not Buildkite conditional syntax"}
@@ -192,9 +208,13 @@ func validateOperators(expr ast.Expression) error {
 func referencesRoot(expr ast.Expression, root string) bool {
 	switch expr := expr.(type) {
 	case *ast.Identifier:
-		return expr.Value == root
+		return expr.Value == root || strings.HasPrefix(expr.Value, root+".")
 	case *ast.PrefixExpression:
 		return referencesRoot(expr.Right, root)
+	case *ast.ConditionalExpression:
+		return referencesRoot(expr.Condition, root) ||
+			referencesRoot(expr.Consequence, root) ||
+			referencesRoot(expr.Alternative, root)
 	case *ast.InfixExpression:
 		return referencesRoot(expr.Left, root) || referencesRoot(expr.Right, root)
 	case *ast.CallExpression:

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -343,8 +343,8 @@ Initial manifest:
 
 | Upstream source | Groups to account for | Current status | Required status before parity claim |
 | --- | --- | --- | --- |
-| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 2 seeds source-tagged root cases for comments, simple expressions, precedence, and local rejection of `@>`; full parser grammar parity is Slice 3 | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 2 seeds source-tagged root cases for booleans, null comparisons, string comparisons, array string includes, regexes, and short-circuiting; ternaries, shell substitutions, enum behavior, null-regex semantics, and array-regex includes remain Slice 4 work | `ported` |
+| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; complex string interpolation, exact friendly messages, and token positions remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 3 adds ternary evaluation; shell substitution evaluation, enum behavior, null-regex semantics, and array-regex includes remain Slice 4 work | `ported` |
 | `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: typed context model is Slice 4 and Slice 5 | `ported` or `superseded` by Go type/context tests |
 | `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Slice 2 seeds source-tagged root cases for representative `env()`, `build.env()`, organization, pipeline, webhook, pull request label, project env merge, and validation behavior; the exhaustive context matrix is Slice 5 | `ported` |
 | `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: Slice 2 ports blank string, invalid expression, step-variable rejection, and step-option acceptance through root validation; nil validation is not representable in the string API | `ported` or `intentionally_excluded` with reason |
@@ -377,23 +377,34 @@ from this plan.
 - Parser rejects trailing tokens after a complete expression.
 - Lexer handles unterminated regex literals without panicking.
 - README documents the current regex interpolation boundary.
-- Some landed behavior is now explicitly provisional because it diverges from
-  the server grammar or server regex validator.
+- Slice 1 landed the root package API, server-derived entrypoint model, public
+  context structs, typed error categories, root smoke tests, and package
+  migration map.
+- Slice 2 landed the source-tagged, table-driven root conformance suite. The
+  suite keeps test data in Go code, requires every root conformance case to name
+  its docs or upstream `buildkite/buildkite` source, and splits behavior across
+  syntax, evaluation, regex, context, and root API error test files.
+- Some landed behavior is still explicitly provisional because it diverges from
+  the server regex validator or still lacks the server type checker.
 
 ### Active Slice
 
-- Slice 2 is creating the source-tagged, table-driven root conformance suite.
-  The suite keeps test data in Go code and uses a small helper instead of YAML
-  fixtures.
-- Root package cases now carry a `source` string that points to the public docs
-  or the upstream `buildkite/buildkite` spec/model file that motivated the case.
+- Slice 3 is aligning parser grammar with the server grammar.
+- Dotted variable identifiers now parse as flat assignment names, not nested dot
+  expressions.
+- Dotted function identifiers now parse as flat function names, including
+  `build.env(...)`.
+- Ternary expressions parse with server precedence and evaluate lazily through
+  the current evaluator.
+- Shell expansion operands such as `$branch`, `${branch:-fallback}`, and nested
+  substring expressions tokenize and parse as shell expansion AST nodes. Full
+  evaluation semantics and double-quoted string interpolation remain Slice 4
+  work because they require the environment substitution evaluator.
+- `@>` is removed from the parser surface and now fails as a parse error instead
+  of being parsed then rejected later by root validation.
 - Server-supported cases that the current implementation cannot pass are not
   added as skipped tests. They remain recorded in the manifest and known gaps
   until the parser, evaluator, context, and regex parity slices implement them.
-- Slice 1 introduced the root package API, server-derived entrypoint model,
-  public context structs, typed error categories, root smoke tests, and package
-  migration map. If it is not yet merged into `master`, Slice 2 stays stacked on
-  that branch.
 - `docs/plans/buildkite-conditionals-package-migration.md` records the intended
   movement from public implementation packages to `internal/` once the root API
   is ready to own the parity contract.
@@ -402,16 +413,16 @@ from this plan.
 
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
-| Dotted names | The root adapter supplies flat assignment keys for server variables, but parser/evaluator internals still keep the older nested-object fallback. | Match the server grammar's flat dotted identifiers throughout parser, type checker, and evaluator internals. |
-| `build.env()` | The root adapter supports `build.env("NAME")` as a flat function identifier, but full validator coverage still belongs in the conformance slices. | Treat `build.env` as a flat function identifier with server-compatible nullable return behavior across validation and conformance tests. |
-| Ternary syntax | Not implemented. | Implement server ternary `condition ? true_value : false_value` precedence and type checking. |
-| Shell substitution | Not implemented. | Implement server grammar for `$name`, `${name}`, default/alternate/error forms, and substring forms. |
+| Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables. Some public implementation packages still expose older generic-language concepts during transition. | Finish removing nested object lookup assumptions and move implementation packages under `internal/` in the cleanup slice. |
+| `build.env()` | `build.env("NAME")` parses as a flat function identifier and evaluates through the root adapter. | Expand validator and conformance coverage for server-compatible nullable return behavior in Slice 5. |
+| Ternary syntax | Ternaries parse with server precedence and evaluate lazily, but type checking is still runtime-only. | Add server-compatible type checking and error categories in Slice 4. |
+| Shell substitution | Shell expansion operands tokenize and parse. Double-quoted interpolation and substitution evaluation are not implemented yet. | Implement server evaluation for `$name`, `${name}`, default/alternate/error forms, nested fallbacks, double-quoted string interpolation, and substring forms. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |
 | Nullable values | Missing nested properties error. | Documented nullable variables should be present as `null` for the right contexts. Truly unknown properties should still fail closed. |
 | Context restrictions | No context kind. | Enforce pipeline, step, build-notification, and step-notification variable availability. |
 | Final result | `Eval` returns any `object.Object`. Tests often ignore parser errors. | Public Buildkite evaluation should return `(bool, error)` and treat non-boolean results as errors. |
 | Regex syntax | regexp2 accepts some features the server rejects. | Keep regexp2 only with a server-compatible validator for flags and unsupported constructs. |
-| Divergent operators | `@>` exists locally but is not server syntax. | Remove it from the Buildkite language and tests. |
+| Divergent operators | `@>` no longer tokenizes as a Buildkite parser operator. Some lower-level compatibility constants may remain until cleanup. | Remove remaining dead `@>` constants or generic-language artifacts in the cleanup slice. |
 | Type mismatch semantics | Local behavior exists but is not server-proven. | Build a server-derived matrix for equality, regex matching, `includes`, `!`, missing values, and function argument errors. |
 | Conformance | Root package tests are now split into source-tagged table-driven files for syntax, evaluation, regex, context, and root API error behavior. The tables seed docs and upstream spec coverage but do not yet port every blocked upstream group. | Expand the tables in each implementation slice until every manifest group is `ported`, `superseded`, or `intentionally_excluded` before claiming parity. |
 
@@ -678,6 +689,8 @@ Current Slice 2 progress:
   notification specs. The manifest remains `blocked` for every upstream group
   that still needs feature work rather than skipped tests.
 
+Status: landed.
+
 ### Slice 3: Parser Grammar Parity
 
 Make the parser match `app/models/conditional/grammar.kpeg`.
@@ -695,6 +708,17 @@ Definition of done:
   grammar.
 - Parser no-panic tests cover unterminated strings, regexes, comments,
   substitutions, and deeply nested expressions.
+
+Current Slice 3 progress:
+
+- Flat dotted identifiers and dotted function names are implemented.
+- Ternary parsing and lazy evaluation are implemented.
+- Shell expansion operands are tokenized and parsed, including nested brace
+  forms used by substring expressions.
+- Double-quoted string interpolation remains blocked until Slice 4's environment
+  substitution evaluator. That evaluator needs to distinguish unset, null, and
+  empty values and cannot be represented by the current `StringLiteral` alone.
+- `@>` is rejected by the parser rather than by root validation.
 
 ### Slice 4: Type Checking And Evaluation Semantics
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -97,6 +97,24 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "ternary evaluates alternative branch",
+			source:     upstreamEvaluatorSpec,
+			expression: `1 == 2 ? 3 == 4 : 5 == 5`,
+			want:       true,
+		},
+		{
+			name:       "ternary evaluates consequence branch",
+			source:     upstreamEvaluatorSpec,
+			expression: `1 == 1 ? 3 == 4 : 5 == 5`,
+			want:       false,
+		},
+		{
+			name:       "nested ternary is right associative",
+			source:     upstreamEvaluatorSpec,
+			expression: `false ? true : false ? true : true`,
+			want:       true,
+		},
+		{
 			name:       "missing variable fails closed",
 			source:     upstreamBuildConditionSpec,
 			expression: `missing.value == "x"`,

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -33,6 +33,9 @@ func Eval(node ast.Node, scope Scope) object.Object {
 	case *ast.Regexp:
 		return &object.Regexp{Regexp: node.Regexp, Flags: node.Flags}
 
+	case *ast.ShellExpansion:
+		return newError("shell expansion evaluation is not implemented: %s", node.Raw)
+
 	case *ast.Boolean:
 		return nativeBoolToBooleanObject(node.Value)
 
@@ -47,14 +50,6 @@ func Eval(node ast.Node, scope Scope) object.Object {
 		return evalPrefixExpression(node.Operator, right)
 
 	case *ast.InfixExpression:
-		if node.Operator == "." {
-			if key, ok := dottedIdentifier(node); ok {
-				if obj, ok := scope.Get(key); ok {
-					return obj
-				}
-			}
-		}
-
 		left := Eval(node.Left, scope)
 		if isError(left) {
 			return left
@@ -65,20 +60,15 @@ func Eval(node ast.Node, scope Scope) object.Object {
 		}
 
 		var right object.Object
-		if node.Operator == `.` {
-			ident, ok := node.Right.(*ast.Identifier)
-			if !ok {
-				return newError("dot operator must receive identifier")
-			}
-			right = &object.String{Value: ident.Value}
-		} else {
-			right = Eval(node.Right, scope)
-		}
+		right = Eval(node.Right, scope)
 		if isError(right) {
 			return right
 		}
 
 		return evalInfixExpression(node.Operator, left, right)
+
+	case *ast.ConditionalExpression:
+		return evalConditionalExpression(node, scope)
 
 	case *ast.Identifier:
 		return evalIdentifier(node, scope)
@@ -108,33 +98,28 @@ func Eval(node ast.Node, scope Scope) object.Object {
 	}
 }
 
-func dottedIdentifier(expr ast.Expression) (string, bool) {
-	switch expr := expr.(type) {
-	case *ast.Identifier:
-		return expr.Value, true
-	case *ast.InfixExpression:
-		if expr.Operator != "." {
-			return "", false
-		}
-		left, ok := dottedIdentifier(expr.Left)
-		if !ok {
-			return "", false
-		}
-		right, ok := expr.Right.(*ast.Identifier)
-		if !ok {
-			return "", false
-		}
-		return left + "." + right.Value, true
-	default:
-		return "", false
-	}
-}
-
 func nativeBoolToBooleanObject(input bool) *object.Boolean {
 	if input {
 		return TRUE
 	}
 	return FALSE
+}
+
+func evalConditionalExpression(node *ast.ConditionalExpression, scope Scope) object.Object {
+	condition := Eval(node.Condition, scope)
+	if isError(condition) {
+		return condition
+	}
+
+	conditionVal, ok := condition.(*object.Boolean)
+	if !ok {
+		return newError("conditional condition must be BOOLEAN, got %s", condition.Type())
+	}
+
+	if conditionVal.Value {
+		return Eval(node.Consequence, scope)
+	}
+	return Eval(node.Alternative, scope)
 }
 
 func applyFunction(fn object.Object, args []object.Object) object.Object {
@@ -170,8 +155,6 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 		return evalIntegerInfixExpression(operator, left, right)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.STRING_OBJ:
 		return evalStringInfixExpression(operator, left, right)
-	case operator == "." && left.Type() == object.STRUCT_OBJ && right.Type() == object.STRING_OBJ:
-		return evalDotExpression(left, right)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.REGEXP_OBJ:
 		return evalStringRegexpInfixExpression(operator, left, right)
 	case left.Type() == object.ARRAY_OBJ:
@@ -309,7 +292,7 @@ func evalArrayInfixExpression(operator string, left, right object.Object) object
 	leftVal := left.(*object.Array)
 
 	switch operator {
-	case "@>", "includes":
+	case "includes":
 		contains, err := arrayContains(leftVal, right)
 		if err != nil {
 			return newError("%s", err.Error())
@@ -319,25 +302,6 @@ func evalArrayInfixExpression(operator string, left, right object.Object) object
 		return newError("unknown operator: %s %s %s",
 			left.Type(), operator, right.Type())
 	}
-}
-
-func evalDotExpression(s object.Object, prop object.Object) object.Object {
-	// defer untrace(trace("evalDotExpression", s, prop))
-
-	structVal, ok := s.(object.Struct)
-	if !ok {
-		return newError("type can't be used with the dot operator: %T", s)
-	}
-
-	propVal := prop.(*object.String).Value
-
-	val, ok := structVal.Get(propVal)
-	if !ok {
-		return newError("struct has no property %q", propVal)
-	}
-
-	return val
-
 }
 
 func evalIdentifier(node *ast.Identifier, scope Scope) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/buildkite/conditional/ast"
 	"github.com/buildkite/conditional/object"
@@ -79,7 +80,7 @@ func Eval(node ast.Node, scope Scope) object.Object {
 			return args[0]
 		}
 
-		obj, ok := scope.Get(node.Function)
+		obj, ok := resolveScopedName(node.Function, scope)
 		if !ok {
 			return newError("function not defined: %s", node.Function)
 		}
@@ -307,12 +308,43 @@ func evalArrayInfixExpression(operator string, left, right object.Object) object
 func evalIdentifier(node *ast.Identifier, scope Scope) object.Object {
 	// defer untrace(trace("evalIdentifier"))
 
-	val, ok := scope.Get(node.Value)
+	val, ok := resolveScopedName(node.Value, scope)
 	if !ok {
 		return newError("identifier not found: %s", node.Value)
 	}
 
 	return val
+}
+
+func resolveScopedName(name string, scope Scope) (object.Object, bool) {
+	if val, ok := scope.Get(name); ok {
+		return val, true
+	}
+
+	if !strings.Contains(name, ".") {
+		return nil, false
+	}
+
+	var current Scope = scope
+	parts := strings.Split(name, ".")
+	for i, part := range parts {
+		val, ok := current.Get(part)
+		if !ok {
+			return nil, false
+		}
+
+		if i == len(parts)-1 {
+			return val, true
+		}
+
+		next, ok := val.(Scope)
+		if !ok {
+			return nil, false
+		}
+		current = next
+	}
+
+	return nil, false
 }
 
 func newError(format string, a ...interface{}) *object.Error {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -166,6 +166,29 @@ func TestFlatDottedIdentifier(t *testing.T) {
 	}
 }
 
+func TestNestedDottedIdentifierFallback(t *testing.T) {
+	scope := object.Struct{
+		"build": object.Struct{
+			"message": &object.String{Value: "deploy"},
+		},
+	}
+
+	evaluated := testEvalWithScope(`build.message == "deploy"`, scope)
+	testBooleanObject(t, evaluated, true)
+}
+
+func TestFlatDottedIdentifierTakesPrecedence(t *testing.T) {
+	scope := object.Struct{
+		"build.message": &object.String{Value: "flat"},
+		"build": object.Struct{
+			"message": &object.String{Value: "nested"},
+		},
+	}
+
+	evaluated := testEvalWithScope(`build.message == "flat"`, scope)
+	testBooleanObject(t, evaluated, true)
+}
+
 func TestFlatDottedIdentifierFailsOnMissingAssignment(t *testing.T) {
 	obj := testEvalWithScope(`foo.bar`, object.Struct{})
 
@@ -177,6 +200,19 @@ func TestFlatDottedIdentifierFailsOnMissingAssignment(t *testing.T) {
 	if result.Message != `identifier not found: foo.bar` {
 		t.Fatalf("bad error message: %v", result.Message)
 	}
+}
+
+func TestNestedDottedFunctionFallback(t *testing.T) {
+	scope := object.Struct{
+		"build": object.Struct{
+			"env": object.Function(func(args []object.Object) object.Object {
+				return &object.String{Value: "from-nested"}
+			}),
+		},
+	}
+
+	evaluated := testEvalWithScope(`build.env("FOO") == "from-nested"`, scope)
+	testBooleanObject(t, evaluated, true)
 }
 
 func TestContainsOperator(t *testing.T) {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -77,11 +77,7 @@ func TestBangOperator(t *testing.T) {
 
 func TestEvalBooleanObjectComparison(t *testing.T) {
 	scope := object.Struct{
-		"build": object.Struct{
-			"pull_request": object.Struct{
-				"draft": &object.Boolean{Value: false},
-			},
-		},
+		"build.pull_request.draft": &object.Boolean{Value: false},
 	}
 
 	evaluated := testEvalWithScope(`build.pull_request.draft == false`, scope)
@@ -90,9 +86,7 @@ func TestEvalBooleanObjectComparison(t *testing.T) {
 
 func TestEvalNullComparison(t *testing.T) {
 	scope := object.Struct{
-		"build": object.Struct{
-			"tag": &object.Null{},
-		},
+		"build.tag": &object.Null{},
 	}
 
 	tests := []struct {
@@ -154,7 +148,7 @@ func TestCallOperator(t *testing.T) {
 	}
 }
 
-func TestDotOperator(t *testing.T) {
+func TestFlatDottedIdentifier(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected bool
@@ -163,11 +157,7 @@ func TestDotOperator(t *testing.T) {
 	}
 
 	scope := object.Struct{
-		`foo`: object.Struct{
-			`bar`: object.Struct{
-				`baz`: &object.String{Value: "test"},
-			},
-		},
+		`foo.bar.baz`: &object.String{Value: "test"},
 	}
 
 	for _, tt := range tests {
@@ -176,17 +166,15 @@ func TestDotOperator(t *testing.T) {
 	}
 }
 
-func TestDotOperatorFailsOnMissingStructProperty(t *testing.T) {
-	obj := testEvalWithScope(`foo.bar`, object.Struct{
-		`foo`: object.Struct{},
-	})
+func TestFlatDottedIdentifierFailsOnMissingAssignment(t *testing.T) {
+	obj := testEvalWithScope(`foo.bar`, object.Struct{})
 
 	result, ok := obj.(*object.Error)
 	if !ok {
 		t.Fatalf("result is not an error. got=%T (%+v)", obj, obj)
 	}
 
-	if result.Message != `struct has no property "bar"` {
+	if result.Message != `identifier not found: foo.bar` {
 		t.Fatalf("bad error message: %v", result.Message)
 	}
 }
@@ -198,9 +186,6 @@ func TestContainsOperator(t *testing.T) {
 	}{
 		{`["llamas","alpacas"] includes 'alpacas'`, true},
 		{`["llamas","alpacas"] includes 'sheep'`, false},
-		{`["llamas","alpacas"] @> 'alpacas'`, true},
-		{`["llamas","alpacas"] @> 'sheep'`, false},
-		{`[1,2,3] @> 2`, true},
 	}
 
 	for _, tt := range tests {
@@ -211,18 +196,30 @@ func TestContainsOperator(t *testing.T) {
 
 func TestContainsOperatorWithScopeArray(t *testing.T) {
 	scope := object.Struct{
-		"build": object.Struct{
-			"creator": object.Struct{
-				"teams": &object.Array{Elements: []object.Object{
-					&object.String{Value: "deploy"},
-					&object.String{Value: "platform"},
-				}},
-			},
-		},
+		"build.creator.teams": &object.Array{Elements: []object.Object{
+			&object.String{Value: "deploy"},
+			&object.String{Value: "platform"},
+		}},
 	}
 
 	evaluated := testEvalWithScope(`build.creator.teams includes "deploy"`, scope)
 	testBooleanObject(t, evaluated, true)
+}
+
+func TestConditionalExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`1 == 2 ? 3 == 4 : 5 == 5`, true},
+		{`1 == 1 ? 3 == 4 : 5 == 5`, false},
+		{`false ? true : false ? true : true`, true},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testBooleanObject(t, evaluated, tt.expected)
+	}
 }
 
 func testEval(input string) object.Object {
@@ -233,6 +230,9 @@ func testEvalWithScope(input string, scope Scope) object.Object {
 	l := lexer.New(input)
 	p := parser.New(l)
 	expr := p.Parse()
+	if len(p.Errors()) > 0 {
+		return &object.Error{Message: p.Errors()[0]}
+	}
 	return Eval(expr, scope)
 }
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -75,22 +75,39 @@ func (l *Lexer) NextToken() token.Token {
 			tok = newToken(token.ILLEGAL, l.ch)
 		}
 	case '@':
-		if l.peekChar() == '>' {
-			ch := l.ch
-			l.readChar()
-			literal := string(ch) + string(l.ch)
-			tok = token.Token{Type: token.CONTAINS, Literal: literal}
-		} else {
-			tok = newToken(token.ILLEGAL, l.ch)
-		}
+		tok = newToken(token.ILLEGAL, l.ch)
 	case '.':
 		tok = newToken(token.DOT, l.ch)
+	case '?':
+		tok = newToken(token.QUESTION, l.ch)
+	case ':':
+		tok = newToken(token.COLON, l.ch)
+	case '$':
+		tok.Type = token.SHELL
+		var ok bool
+		tok.Literal, ok = l.readShell()
+		if !ok {
+			tok.Type = token.ILLEGAL
+		}
+		return tok
 	case '"':
 		tok.Type = token.STRING
-		tok.Literal = l.readString('"')
+		var terminated bool
+		tok.Literal, terminated = l.readString('"')
+		tok.Flags = `"`
+		if !terminated {
+			tok.Type = token.ILLEGAL
+			tok.Flags = ""
+		}
 	case '\'':
 		tok.Type = token.STRING
-		tok.Literal = l.readString('\'')
+		var terminated bool
+		tok.Literal, terminated = l.readString('\'')
+		tok.Flags = `'`
+		if !terminated {
+			tok.Type = token.ILLEGAL
+			tok.Flags = ""
+		}
 	case '/':
 		tok.Type = token.REGEXP
 		var terminated bool
@@ -171,7 +188,7 @@ func (l *Lexer) peekChar() byte {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
-	for isLetter(l.ch) {
+	for isIdentPart(l.ch) {
 		l.readChar()
 	}
 	return l.input[position:l.position]
@@ -185,15 +202,64 @@ func (l *Lexer) readNumber() string {
 	return l.input[position:l.position]
 }
 
-func (l *Lexer) readString(quote byte) string {
+func (l *Lexer) readString(quote byte) (string, bool) {
 	position := l.position + 1
+	escaped := false
 	for {
 		l.readChar()
-		if l.ch == quote || l.ch == 0 {
-			break
+		if l.ch == 0 {
+			return l.input[position:l.position], false
+		}
+		if l.ch == quote && !escaped {
+			return l.input[position:l.position], true
+		}
+		escaped = l.ch == '\\' && !escaped
+		if l.ch != '\\' {
+			escaped = false
 		}
 	}
-	return l.input[position:l.position]
+}
+
+func (l *Lexer) readShell() (string, bool) {
+	position := l.position
+	l.readChar()
+
+	if isIdentStart(l.ch) {
+		for isIdentPart(l.ch) {
+			l.readChar()
+		}
+		return l.input[position:l.position], true
+	}
+
+	if l.ch != '{' {
+		l.readChar()
+		return l.input[position:l.position], false
+	}
+
+	depth := 1
+	escaped := false
+	for {
+		l.readChar()
+		if l.ch == 0 {
+			return l.input[position:l.position], false
+		}
+
+		switch {
+		case l.ch == '\\' && !escaped:
+			escaped = true
+			continue
+		case l.ch == '{' && !escaped:
+			depth++
+		case l.ch == '}' && !escaped:
+			depth--
+			if depth == 0 {
+				l.readChar()
+				return l.input[position:l.position], true
+			}
+		}
+
+		escaped = false
+	}
 }
 
 func (l *Lexer) readRegex() (string, string, bool) {
@@ -230,8 +296,16 @@ func (l *Lexer) readRegex() (string, string, bool) {
 	return literal, l.input[flagsPosition:l.readPosition], true
 }
 
-func isLetter(ch byte) bool {
+func isIdentStart(ch byte) bool {
 	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+}
+
+func isLetter(ch byte) bool {
+	return isIdentStart(ch)
+}
+
+func isIdentPart(ch byte) bool {
+	return isIdentStart(ch) || isDigit(ch) || ch == '.'
 }
 
 func isDigit(ch byte) bool {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -26,19 +26,24 @@ func TestLexingIndividualTerms(t *testing.T) {
 	})
 }
 
+func TestLexingUnterminatedStrings(t *testing.T) {
+	expectTokens(t, `"from prison \`, []tokenExpectation{
+		{token.ILLEGAL, `from prison \`},
+	})
+	expectTokens(t, `'mad lad opening single quotes`, []tokenExpectation{
+		{token.ILLEGAL, `mad lad opening single quotes`},
+	})
+}
+
 func TestLexingValueComparisons(t *testing.T) {
 	expectTokens(t, `build.branch == "master"`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "branch"},
+		{token.IDENT, "build.branch"},
 		{token.EQ, "=="},
 		{token.STRING, "master"},
 	})
 	expectTokens(t, `(build.tag != "v1.0.0")`, []tokenExpectation{
 		{token.LPAREN, "("},
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "tag"},
+		{token.IDENT, "build.tag"},
 		{token.NOT_EQ, "!="},
 		{token.STRING, "v1.0.0"},
 		{token.RPAREN, ")"},
@@ -70,34 +75,34 @@ func TestLexingFunctionCalls(t *testing.T) {
 		{token.EQ, "=="},
 		{token.STRING, "FOO"},
 	})
+	expectTokens(t, `build.env("FOO") == "BAR"`, []tokenExpectation{
+		{token.IDENT, "build.env"},
+		{token.LPAREN, "("},
+		{token.STRING, "FOO"},
+		{token.RPAREN, ")"},
+		{token.EQ, "=="},
+		{token.STRING, "BAR"},
+	})
 }
 
 func TestLexingRegexps(t *testing.T) {
 	expectTokens(t, `build.tag =~ /^v/`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "tag"},
+		{token.IDENT, "build.tag"},
 		{token.RE_EQ, "=~"},
 		{token.REGEXP, "^v"},
 	})
 	expectTokens(t, `build.branch =~ /^features\//`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "branch"},
+		{token.IDENT, "build.branch"},
 		{token.RE_EQ, "=~"},
 		{token.REGEXP, `^features\/`},
 	})
 	expectTokens(t, `build.branch =~ /\/release-123\$/`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "branch"},
+		{token.IDENT, "build.branch"},
 		{token.RE_EQ, "=~"},
 		{token.REGEXP, `\/release-123\$`},
 	})
 	expectTokens(t, `build.message !~ /\[skip tests\]/i`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "message"},
+		{token.IDENT, "build.message"},
 		{token.RE_NOT_EQ, "!~"},
 		{token.REGEXP, `\[skip tests\]`},
 	})
@@ -119,9 +124,7 @@ func TestLexingRegexps(t *testing.T) {
 
 func TestLexingUnterminatedRegexp(t *testing.T) {
 	expectTokens(t, `build.branch =~ /release`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "branch"},
+		{token.IDENT, "build.branch"},
 		{token.RE_EQ, "=~"},
 		{token.ILLEGAL, "release"},
 	})
@@ -129,22 +132,56 @@ func TestLexingUnterminatedRegexp(t *testing.T) {
 
 func TestLexingArrays(t *testing.T) {
 	expectTokens(t, `build.creator.teams includes "deploy"`, []tokenExpectation{
-		{token.IDENT, "build"},
-		{token.DOT, "."},
-		{token.IDENT, "creator"},
-		{token.DOT, "."},
-		{token.IDENT, "teams"},
+		{token.IDENT, "build.creator.teams"},
 		{token.INCLUDES, "includes"},
 		{token.STRING, "deploy"},
 	})
+}
+
+func TestLexingRejectsNonServerContainsOperator(t *testing.T) {
 	expectTokens(t, `["llamas", "alpacas"] @> "alpacas"`, []tokenExpectation{
 		{token.LBRACKET, "["},
 		{token.STRING, "llamas"},
 		{token.COMMA, ","},
 		{token.STRING, "alpacas"},
 		{token.RBRACKET, "]"},
-		{token.CONTAINS, "@>"},
+		{token.ILLEGAL, "@"},
+		{token.ILLEGAL, ">"},
 		{token.STRING, "alpacas"},
+	})
+}
+
+func TestLexingTernaries(t *testing.T) {
+	expectTokens(t, `true ? false : true`, []tokenExpectation{
+		{token.TRUE, "true"},
+		{token.QUESTION, "?"},
+		{token.FALSE, "false"},
+		{token.COLON, ":"},
+		{token.TRUE, "true"},
+	})
+}
+
+func TestLexingShellExpansions(t *testing.T) {
+	expectTokens(t, `$branch == "main"`, []tokenExpectation{
+		{token.SHELL, "$branch"},
+		{token.EQ, "=="},
+		{token.STRING, "main"},
+	})
+	expectTokens(t, `${branch:-main} == "main"`, []tokenExpectation{
+		{token.SHELL, "${branch:-main}"},
+		{token.EQ, "=="},
+		{token.STRING, "main"},
+	})
+	expectTokens(t, `${branch:${empty:-1}:${two+2}} == "ai"`, []tokenExpectation{
+		{token.SHELL, "${branch:${empty:-1}:${two+2}}"},
+		{token.EQ, "=="},
+		{token.STRING, "ai"},
+	})
+}
+
+func TestLexingUnterminatedShellExpansion(t *testing.T) {
+	expectTokens(t, `${branch:-main == "main"`, []tokenExpectation{
+		{token.ILLEGAL, `${branch:-main == "main"`},
 	})
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildkite/conditional/ast"
@@ -16,6 +17,7 @@ const regexpMatchTimeout = time.Second
 const (
 	_ int = iota
 	LOWEST
+	TERNARY
 	OR     // ||
 	AND    // &&
 	EQUALS // ==
@@ -33,6 +35,7 @@ var precedences = map[token.TokenType]int{
 	token.INCLUDES:  EQUALS,
 	token.AND:       AND,
 	token.OR:        OR,
+	token.QUESTION:  TERNARY,
 	token.LPAREN:    CALL,
 	token.DOT:       DOT,
 }
@@ -64,6 +67,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
 	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	p.registerPrefix(token.REGEXP, p.parseRegexp)
+	p.registerPrefix(token.SHELL, p.parseShellExpansion)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
@@ -76,11 +80,10 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.NOT_EQ, p.parseInfixExpression)
 	p.registerInfix(token.RE_EQ, p.parseInfixExpression)
 	p.registerInfix(token.RE_NOT_EQ, p.parseInfixExpression)
-	p.registerInfix(token.CONTAINS, p.parseInfixExpression)
 	p.registerInfix(token.INCLUDES, p.parseInfixExpression)
 	p.registerInfix(token.AND, p.parseInfixExpression)
 	p.registerInfix(token.OR, p.parseInfixExpression)
-	p.registerInfix(token.DOT, p.parseInfixExpression)
+	p.registerInfix(token.QUESTION, p.parseConditionalExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 
 	// Read two tokens, so curToken and peekToken are both set
@@ -192,7 +195,16 @@ func (p *Parser) curPrecedence() int {
 
 func (p *Parser) parseIdentifier() ast.Expression {
 	// defer untrace(trace("parseIdentifier", p.curToken))
+	if invalidDottedIdentifier(p.curToken.Literal) {
+		msg := fmt.Sprintf("invalid dotted identifier: %s", p.curToken.Literal)
+		p.errors = append(p.errors, msg)
+		return nil
+	}
 	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func invalidDottedIdentifier(value string) bool {
+	return strings.HasPrefix(value, ".") || strings.HasSuffix(value, ".") || strings.Contains(value, "..")
 }
 
 func (p *Parser) parseIntegerLiteral() ast.Expression {
@@ -213,6 +225,10 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 
 func (p *Parser) parseStringLiteral() ast.Expression {
 	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
+}
+
+func (p *Parser) parseShellExpansion() ast.Expression {
+	return &ast.ShellExpansion{Token: p.curToken, Raw: p.curToken.Literal}
 }
 
 func (p *Parser) parseRegexp() ast.Expression {
@@ -279,6 +295,25 @@ func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {
 	precedence := p.curPrecedence()
 	p.nextToken()
 	expression.Right = p.parseExpression(precedence)
+
+	return expression
+}
+
+func (p *Parser) parseConditionalExpression(condition ast.Expression) ast.Expression {
+	expression := &ast.ConditionalExpression{
+		Token:     p.curToken,
+		Condition: condition,
+	}
+
+	p.nextToken()
+	expression.Consequence = p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.COLON) {
+		return nil
+	}
+
+	p.nextToken()
+	expression.Alternative = p.parseExpression(TERNARY - 1)
 
 	return expression
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -144,7 +144,6 @@ func TestParsingInfixExpressions(t *testing.T) {
 		{"5 != 5", 5, "!=", 5},
 		{`"a" == "a"`, "a", "==", "a"},
 		{`"a" != "b"`, "a", "!=", "b"},
-		{"foo.bar", "foo", ".", "bar"},
 		{"foobar != barfoo", "foobar", "!=", "barfoo"},
 		{"true == true", true, "==", true},
 		{"true != false", true, "!=", false},
@@ -164,6 +163,97 @@ func TestParsingInfixExpressions(t *testing.T) {
 	}
 }
 
+func TestDottedIdentifierExpression(t *testing.T) {
+	tests := []string{
+		"foo.bar",
+		"foo.bar.baz",
+		"build.pull_request.repository.fork",
+	}
+
+	for _, input := range tests {
+		l := lexer.New(input)
+		p := New(l)
+		expr := p.Parse()
+		checkParserErrors(t, p)
+
+		ident, ok := expr.(*ast.Identifier)
+		if !ok {
+			t.Fatalf("expr is not ast.Identifier. got=%T", expr)
+		}
+		if ident.Value != input {
+			t.Fatalf("identifier value = %q, want %q", ident.Value, input)
+		}
+	}
+}
+
+func TestParserRejectsMalformedDottedIdentifiers(t *testing.T) {
+	tests := []string{
+		"foo.",
+		"foo..bar",
+	}
+
+	for _, input := range tests {
+		l := lexer.New(input)
+		p := New(l)
+		p.Parse()
+
+		if len(p.Errors()) == 0 {
+			t.Fatalf("expected parser errors for %q", input)
+		}
+	}
+}
+
+func TestParserRejectsUnterminatedStrings(t *testing.T) {
+	tests := []string{
+		`"from prison \`,
+		`'mad lad opening single quotes`,
+	}
+
+	for _, input := range tests {
+		l := lexer.New(input)
+		p := New(l)
+		p.Parse()
+
+		if len(p.Errors()) == 0 {
+			t.Fatalf("expected parser errors for %q", input)
+		}
+	}
+}
+
+func TestShellExpansionExpression(t *testing.T) {
+	tests := []string{
+		"$branch",
+		"${branch}",
+		"${branch:-main}",
+		"${branch:${empty:-1}:${two+2}}",
+	}
+
+	for _, input := range tests {
+		l := lexer.New(input)
+		p := New(l)
+		expr := p.Parse()
+		checkParserErrors(t, p)
+
+		expansion, ok := expr.(*ast.ShellExpansion)
+		if !ok {
+			t.Fatalf("expr is not ast.ShellExpansion. got=%T", expr)
+		}
+		if expansion.Raw != input {
+			t.Fatalf("shell expansion raw = %q, want %q", expansion.Raw, input)
+		}
+	}
+}
+
+func TestParserRejectsUnterminatedShellExpansion(t *testing.T) {
+	l := lexer.New(`${branch:-main == "main"`)
+	p := New(l)
+	p.Parse()
+
+	if len(p.Errors()) == 0 {
+		t.Fatalf("expected parser errors")
+	}
+}
+
 func TestOperatorPrecedenceParsing(t *testing.T) {
 	tests := []struct {
 		input    string
@@ -173,12 +263,14 @@ func TestOperatorPrecedenceParsing(t *testing.T) {
 		{"true", "true"},
 		{"false", "false"},
 		{"!(true == true)", "(!(true == true))"},
-		{"foo.bar.baz == true", "(((foo.bar).baz) == true)"},
-		{"foo.bar == true && bar.baz == false", "(((foo.bar) == true) && ((bar.baz) == false))"},
+		{"foo.bar.baz == true", "(foo.bar.baz == true)"},
+		{"foo.bar == true && bar.baz == false", "((foo.bar == true) && (bar.baz == false))"},
 		{"a || b && c", "(a || (b && c))"},
 		{"a && b || c", "((a && b) || c)"},
 		{"env(env(LLAMAS)) == true", "(env(env(LLAMAS)) == true)"},
 		{"a =~ /a/ && b =~ /b/", "((a =~ /a/) && (b =~ /b/))"},
+		{"true ? false : true", "(true ? false : true)"},
+		{"a || b ? c || d : e || f ? g : h", "((a || b) ? (c || d) : ((e || f) ? g : h))"},
 	}
 
 	for _, tt := range tests {
@@ -316,6 +408,29 @@ func TestCallExpressionParameterParsing(t *testing.T) {
 	}
 }
 
+func TestDottedCallExpressionParsing(t *testing.T) {
+	l := lexer.New(`build.env("FOO") == "BAR"`)
+	p := New(l)
+	expr := p.Parse()
+	checkParserErrors(t, p)
+
+	infix, ok := expr.(*ast.InfixExpression)
+	if !ok {
+		t.Fatalf("expr is not ast.InfixExpression. got=%T", expr)
+	}
+	call, ok := infix.Left.(*ast.CallExpression)
+	if !ok {
+		t.Fatalf("left expr is not ast.CallExpression. got=%T", infix.Left)
+	}
+	if call.Function != "build.env" {
+		t.Fatalf("function = %q, want %q", call.Function, "build.env")
+	}
+	if len(call.Arguments) != 1 {
+		t.Fatalf("wrong number of arguments. want=1, got=%d", len(call.Arguments))
+	}
+	testLiteralExpression(t, call.Arguments[0], "FOO")
+}
+
 func TestParsingEmptyArrayLiterals(t *testing.T) {
 	input := "[]"
 
@@ -361,7 +476,6 @@ func TestParsingContainsOperators(t *testing.T) {
 		operator string
 	}{
 		{`build.creator.teams includes "deploy"`, "includes"},
-		{`["llamas", "alpacas"] @> "llamas"`, "@>"},
 	}
 
 	for _, tt := range tests {
@@ -378,6 +492,16 @@ func TestParsingContainsOperators(t *testing.T) {
 		if iexpr.Operator != tt.operator {
 			t.Fatalf("exp doesn't have expected contains operator. want=%s got=%s", tt.operator, iexpr.Operator)
 		}
+	}
+}
+
+func TestParserRejectsNonServerContainsOperator(t *testing.T) {
+	l := lexer.New(`["llamas", "alpacas"] @> "llamas"`)
+	p := New(l)
+	p.Parse()
+
+	if len(p.Errors()) == 0 {
+		t.Fatalf("expected parser errors")
 	}
 }
 

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -96,14 +96,20 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindParse,
 		},
 		{
-			name:       "validation rejects local-only contains operator",
+			name:       "parse error for malformed dotted identifier",
+			source:     upstreamParserSpec,
+			expression: `build..branch == "main"`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "parser rejects local-only contains operator",
 			source:     upstreamParserSpec,
 			expression: `["main"] @> build.branch`,
 			ctx: Context{
 				EntryPoint: EntryPointBuildCondition,
 				Build:      Build{Branch: str("main")},
 			},
-			wantError: ErrorKindValidation,
+			wantError: ErrorKindParse,
 		},
 		{
 			name:       "validation rejects env without an argument",
@@ -125,14 +131,14 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 func TestConditionalSyntaxEvaluationErrors(t *testing.T) {
 	tests := []evaluateCase{
 		{
-			name:       "evaluation rejects local-only contains operator",
+			name:       "evaluation rejects local-only contains operator at parse time",
 			source:     upstreamParserSpec,
 			expression: `["main"] @> build.branch`,
 			ctx: Context{
 				EntryPoint: EntryPointBuildCondition,
 				Build:      Build{Branch: str("main")},
 			},
-			wantError: ErrorKindValidation,
+			wantError: ErrorKindParse,
 		},
 		{
 			name:       "evaluation rejects literal unsupported Buildkite env",

--- a/token/token.go
+++ b/token/token.go
@@ -11,6 +11,7 @@ const (
 	INT    = "INT"    // 1343456
 	STRING = "STRING" // "foobar"
 	REGEXP = "REGEXP" // /^v1.0/
+	SHELL  = "SHELL"  // $branch, ${branch:-fallback}
 
 	BANG = "!"
 	DOT  = "."
@@ -28,6 +29,8 @@ const (
 	OR  = "||"
 
 	// Delimiters
+	QUESTION = "?"
+	COLON    = ":"
 	COMMA    = ","
 	LPAREN   = "("
 	RPAREN   = ")"


### PR DESCRIPTION
The local grammar still diverged from Buildkite's server-side conditionals in a few visible places: dotted names were modeled as nested field access, the legacy `@>` operator still tokenized, ternary expressions were unavailable, and shell-style substitution operands did not parse.

This narrows that gap by treating dotted identifiers and function names as flat grammar tokens, adding ternary parsing and evaluation, tokenizing shell expansion operands, rejecting malformed dotted names plus unterminated strings and shell expansions, and updating the parity plan with the remaining shell interpolation/evaluator work.

Behaviorally, `build.env("FOO")` now parses as a flat function call and `foo @> bar` fails during parsing instead of reaching validation. Shell expansions currently parse as operands only; evaluation and double-quoted interpolation stay in the next parity slice.