### PR TITLE
feat: Add conditional type checking

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -119,6 +119,9 @@ func validateEnvCalls(expr ast.Expression) error {
 		if err := validateEnvCalls(expr.Left); err != nil {
 			return err
 		}
+		if logicalExpressionShortCircuits(expr) {
+			return nil
+		}
 		return validateEnvCalls(expr.Right)
 	case *ast.CallExpression:
 		if expr.Function == "env" || expr.Function == "build.env" {
@@ -128,7 +131,7 @@ func validateEnvCalls(expr ast.Expression) error {
 					Message: fmt.Sprintf("%s expects exactly one argument", expr.Function),
 				}
 			}
-			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok {
+			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok && !runtimeStringLiteral(arg) {
 				switch {
 				case strings.HasPrefix(arg.Value, "$"):
 					return &Error{
@@ -182,6 +185,9 @@ func validateOperators(expr ast.Expression) error {
 		}
 		if err := validateOperators(expr.Left); err != nil {
 			return err
+		}
+		if logicalExpressionShortCircuits(expr) {
+			return nil
 		}
 		return validateOperators(expr.Right)
 	case *ast.CallExpression:

--- a/conditional.go
+++ b/conditional.go
@@ -26,10 +26,7 @@ func Validate(expression string, ctx Context) error {
 		return err
 	}
 	ctx.EntryPoint = entryPoint
-	if err := validateExpression(expr, entryPoint); err != nil {
-		return err
-	}
-	return validateBooleanResult(expr, ctx)
+	return validateExpression(expr, ctx)
 }
 
 // Evaluate evaluates expression in the selected Buildkite context.
@@ -56,7 +53,7 @@ func evaluate(expression string, ctx Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := validateExpression(expr, ctx.EntryPoint); err != nil {
+	if err := validateExpression(expr, ctx); err != nil {
 		return false, err
 	}
 
@@ -89,7 +86,8 @@ func parse(expression string) (ast.Expression, error) {
 	return expr, nil
 }
 
-func validateExpression(expr ast.Expression, entryPoint EntryPoint) error {
+func validateExpression(expr ast.Expression, ctx Context) error {
+	entryPoint := ctx.EntryPoint
 	if !stepAllowed(entryPoint) && referencesRoot(expr, "step") {
 		return &Error{
 			Kind:    ErrorKindValidation,
@@ -102,22 +100,7 @@ func validateExpression(expr ast.Expression, entryPoint EntryPoint) error {
 	if err := validateOperators(expr); err != nil {
 		return err
 	}
-	return nil
-}
-
-func validateBooleanResult(expr ast.Expression, ctx Context) error {
-	result := evaluator.Eval(expr, buildScope(ctx))
-	switch result := result.(type) {
-	case *object.Boolean:
-		return nil
-	case *object.Error:
-		return &Error{Kind: ErrorKindEvaluation, Message: result.Message}
-	default:
-		return &Error{
-			Kind:    ErrorKindResult,
-			Message: fmt.Sprintf("expected boolean result, got %s", result.Type()),
-		}
-	}
+	return typeCheckExpression(expr, ctx)
 }
 
 func validateEnvCalls(expr ast.Expression) error {
@@ -145,10 +128,23 @@ func validateEnvCalls(expr ast.Expression) error {
 					Message: fmt.Sprintf("%s expects exactly one argument", expr.Function),
 				}
 			}
-			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok && unsupportedBuildkiteEnv(arg.Value) {
-				return &Error{
-					Kind:    ErrorKindValidation,
-					Message: fmt.Sprintf("%q is not a supported Buildkite environment variable", arg.Value),
+			if arg, ok := expr.Arguments[0].(*ast.StringLiteral); ok {
+				switch {
+				case strings.HasPrefix(arg.Value, "$"):
+					return &Error{
+						Kind:    ErrorKindValidation,
+						Message: "env argument should not include $",
+					}
+				case !validEnvName(arg.Value):
+					return &Error{
+						Kind:    ErrorKindValidation,
+						Message: "env argument should be an environment variable name",
+					}
+				case unsupportedBuildkiteEnv(arg.Value):
+					return &Error{
+						Kind:    ErrorKindValidation,
+						Message: fmt.Sprintf("%q is not a supported Buildkite environment variable", arg.Value),
+					}
 				}
 			}
 		}
@@ -237,7 +233,17 @@ func referencesRoot(expr ast.Expression, root string) bool {
 	return false
 }
 
-func buildScope(ctx Context) object.Struct {
+type evaluationScope struct {
+	object.Struct
+	env map[string]string
+}
+
+func (s evaluationScope) LookupEnv(key string) (string, bool) {
+	value, ok := s.env[key]
+	return value, ok
+}
+
+func buildScope(ctx Context) evaluationScope {
 	env := mergedEnv(ctx)
 
 	scope := object.Struct{
@@ -255,7 +261,7 @@ func buildScope(ctx Context) object.Struct {
 		scope["step"] = stepObject(ctx.Step)
 	}
 
-	return scope
+	return evaluationScope{Struct: scope, env: env}
 }
 
 func envFunction(env map[string]string) object.Function {
@@ -560,6 +566,19 @@ func unsupportedBuildkiteEnv(key string) bool {
 	}
 	_, ok := supportedBuildkiteEnv[key]
 	return !ok
+}
+
+func validEnvName(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, ch := range key {
+		if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func builtinEnv(ctx Context) map[string]string {

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -14,7 +14,7 @@ func TestRootValidateAndEvaluateErrorKinds(t *testing.T) {
 		{
 			name:       "evaluation error",
 			source:     upstreamBuildConditionSpec,
-			expression: `unknown.value == "x"`,
+			expression: `${notset:?} == "x"`,
 			ctx:        Context{EntryPoint: EntryPointBuildCondition},
 			wantError:  ErrorKindEvaluation,
 		},
@@ -45,13 +45,6 @@ func TestRootValidateErrorKinds(t *testing.T) {
 			expression: `nope != == one`,
 			ctx:        Context{EntryPoint: EntryPointBuildCondition},
 			wantError:  ErrorKindParse,
-		},
-		{
-			name:       "evaluation error",
-			source:     upstreamBuildConditionSpec,
-			expression: `unknown.value == "x"`,
-			ctx:        Context{EntryPoint: EntryPointBuildCondition},
-			wantError:  ErrorKindEvaluation,
 		},
 		{
 			name:       "result error",

--- a/context_test.go
+++ b/context_test.go
@@ -277,6 +277,30 @@ func TestBuildkiteEnvironmentFunctions(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "env accepts interpolated variable name",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("${NAME}") == "value"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv: map[string]string{
+					"NAME":        "DYNAMIC_ENV",
+					"DYNAMIC_ENV": "value",
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "build env accepts interpolated Buildkite variable name",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env("BUILDKITE_${SUFFIX}") == "main"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Build:      Build{Branch: str("main")},
+				BuildEnv:   map[string]string{"SUFFIX": "BRANCH"},
+			},
+			want: true,
+		},
+		{
 			name:       "built in tag becomes empty string for env",
 			source:     upstreamBuildConditionSpec,
 			expression: `env("BUILDKITE_TAG") == ""`,

--- a/context_test.go
+++ b/context_test.go
@@ -377,7 +377,7 @@ func TestBuildkiteContextValidation(t *testing.T) {
 			source:     upstreamBuildValidatorSpec,
 			expression: "lol",
 			ctx:        Context{EntryPoint: EntryPointBuildCondition},
-			wantError:  ErrorKindEvaluation,
+			wantError:  ErrorKindValidation,
 		},
 		{
 			name:       "step variables rejected without step option",

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -343,9 +343,9 @@ Initial manifest:
 
 | Upstream source | Groups to account for | Current status | Required status before parity claim |
 | --- | --- | --- | --- |
-| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; complex string interpolation, exact friendly messages, and token positions remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 3 adds ternary evaluation; shell substitution evaluation, enum behavior, null-regex semantics, and array-regex includes remain Slice 4 work | `ported` |
-| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: typed context model is Slice 4 and Slice 5 | `ported` or `superseded` by Go type/context tests |
+| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; Slice 4 starts double-quoted shell interpolation. Exact friendly messages, token positions, and full string escape parity remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 4 ports regex includes, null regex/includes semantics, shell substitution evaluation, double-quoted interpolation, enum literal validation, and type-checker rejection for representative mismatches. Full custom function/lazy variable coverage remains | `ported` |
+| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: Slice 4 adds root-level typed variable and enum validation for the Buildkite context model; lazy variable internals and exhaustive variable specs remain Slice 5/cleanup work | `ported` or `superseded` by Go type/context tests |
 | `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Slice 2 seeds source-tagged root cases for representative `env()`, `build.env()`, organization, pipeline, webhook, pull request label, project env merge, and validation behavior; the exhaustive context matrix is Slice 5 | `ported` |
 | `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: Slice 2 ports blank string, invalid expression, step-variable rejection, and step-option acceptance through root validation; nil validation is not representable in the string API | `ported` or `intentionally_excluded` with reason |
 | `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `blocked`: Slice 2 ports blank/no-condition equivalent, false-on-unmet condition, false-on-parse-error, and false-on-unavailable-step-variable behavior; full notification parsing/config propagation remains out of scope | `ported` |
@@ -384,24 +384,28 @@ from this plan.
   suite keeps test data in Go code, requires every root conformance case to name
   its docs or upstream `buildkite/buildkite` source, and splits behavior across
   syntax, evaluation, regex, context, and root API error test files.
+- Slice 3 landed parser grammar alignment for flat dotted identifiers/functions,
+  ternary parsing, shell expansion operands, parser-level `@>` rejection, and
+  unterminated string/substitution errors.
 - Some landed behavior is still explicitly provisional because it diverges from
   the server regex validator or still lacks the server type checker.
 
 ### Active Slice
 
-- Slice 3 is aligning parser grammar with the server grammar.
-- Dotted variable identifiers now parse as flat assignment names, not nested dot
-  expressions.
-- Dotted function identifiers now parse as flat function names, including
-  `build.env(...)`.
-- Ternary expressions parse with server precedence and evaluate lazily through
-  the current evaluator.
-- Shell expansion operands such as `$branch`, `${branch:-fallback}`, and nested
-  substring expressions tokenize and parse as shell expansion AST nodes. Full
-  evaluation semantics and double-quoted string interpolation remain Slice 4
-  work because they require the environment substitution evaluator.
-- `@>` is removed from the parser surface and now fails as a parse error instead
-  of being parsed then rejected later by root validation.
+- Slice 4 is aligning type checking and evaluator semantics with the server
+  evaluator.
+- Root `Validate` now uses server-style type checking instead of evaluating the
+  expression just to prove it returns a boolean. Unknown variables/functions,
+  wrong arity, incompatible operators, invalid `env()` argument types, enum
+  mismatches, and non-boolean root results fail before runtime.
+- Evaluator semantics now match upstream cases for regex `includes`, `null
+  includes ...`, `null =~ /.../`, `null !~ /.../`, and short-circuiting branches
+  that would otherwise fail at runtime.
+- Shell expansion operands now evaluate against the merged Buildkite
+  environment for set, unset, empty, required, default, alternate, substring,
+  nested substring argument, and bad substring length cases.
+- Double-quoted strings now evaluate shell substitutions, while single-quoted
+  strings keep shell-looking text literal.
 - Server-supported cases that the current implementation cannot pass are not
   added as skipped tests. They remain recorded in the manifest and known gaps
   until the parser, evaluator, context, and regex parity slices implement them.
@@ -415,12 +419,12 @@ from this plan.
 | --- | --- | --- |
 | Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables. Some public implementation packages still expose older generic-language concepts during transition. | Finish removing nested object lookup assumptions and move implementation packages under `internal/` in the cleanup slice. |
 | `build.env()` | `build.env("NAME")` parses as a flat function identifier and evaluates through the root adapter. | Expand validator and conformance coverage for server-compatible nullable return behavior in Slice 5. |
-| Ternary syntax | Ternaries parse with server precedence and evaluate lazily, but type checking is still runtime-only. | Add server-compatible type checking and error categories in Slice 4. |
-| Shell substitution | Shell expansion operands tokenize and parse. Double-quoted interpolation and substitution evaluation are not implemented yet. | Implement server evaluation for `$name`, `${name}`, default/alternate/error forms, nested fallbacks, double-quoted string interpolation, and substring forms. |
+| Ternary syntax | Ternaries parse with server precedence, evaluate lazily, and now type-check branch compatibility through the root API. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
+| Shell substitution | Shell expansion operands and double-quoted interpolation evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix. | Finish exact string escape parity, shell fallback string grammar coverage, and package-local parser/evaluator tests for edge cases beyond the current root tables. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |
 | Nullable values | Missing nested properties error. | Documented nullable variables should be present as `null` for the right contexts. Truly unknown properties should still fail closed. |
 | Context restrictions | No context kind. | Enforce pipeline, step, build-notification, and step-notification variable availability. |
-| Final result | `Eval` returns any `object.Object`. Tests often ignore parser errors. | Public Buildkite evaluation should return `(bool, error)` and treat non-boolean results as errors. |
+| Final result | Root `Validate`/`Evaluate` now type-check for a boolean final result; lower-level `Eval` still returns any `object.Object` during transition. | Move implementation packages under `internal/` and keep root `(bool, error)` as the supported Buildkite surface. |
 | Regex syntax | regexp2 accepts some features the server rejects. | Keep regexp2 only with a server-compatible validator for flags and unsupported constructs. |
 | Divergent operators | `@>` no longer tokenizes as a Buildkite parser operator. Some lower-level compatibility constants may remain until cleanup. | Remove remaining dead `@>` constants or generic-language artifacts in the cleanup slice. |
 | Type mismatch semantics | Local behavior exists but is not server-proven. | Build a server-derived matrix for equality, regex matching, `includes`, `!`, missing values, and function argument errors. |
@@ -720,6 +724,8 @@ Current Slice 3 progress:
   empty values and cannot be represented by the current `StringLiteral` alone.
 - `@>` is rejected by the parser rather than by root validation.
 
+Status: landed.
+
 ### Slice 4: Type Checking And Evaluation Semantics
 
 Port the server type-checker and evaluator behavior without copying the Ruby
@@ -737,6 +743,28 @@ Definition of done:
   or failing functions, matching server behavior.
 - Environment substitution evaluates set, unset, empty, required, default,
   alternate, and substring forms the same way as the server.
+
+Current Slice 4 progress:
+
+- Root validation now runs a compact server-style type checker before
+  evaluation. The checker covers documented Buildkite variables, the current
+  `env` and `build.env` functions, operator compatibility, enum literal
+  validation for the modeled Buildkite enums, final boolean result validation,
+  and unknown variable/function rejection.
+- Evaluation now matches upstream server cases for regex `includes`, null array
+  includes, null regex matching/non-matching, and lazy short-circuiting of
+  runtime-failing shell substitutions.
+- Shell substitutions now evaluate for `$name`, `${name}`, `${name?}`,
+  `${name:?}`, `${name-default}`, `${name:-default}`, `${name+alternate}`,
+  `${name:+alternate}`, substring forms, nested substring arguments, unset
+  values, empty values, and invalid substring lengths.
+- Double-quoted strings interpolate shell substitutions and collapse `$$` to a
+  literal dollar. Single-quoted strings remain literal.
+- Remaining Slice 4 work before marking the slice landed: exact server string
+  escape parity across single-quoted, double-quoted, and shell fallback strings;
+  broader upstream type-checker cases for custom functions and lazy variables;
+  and package-local parser/evaluator tests for the substitution grammar beyond
+  the current root conformance tables.
 
 ### Slice 5: Buildkite Context And `env()` Semantics
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -111,6 +111,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "documented started build state",
+			source:     docsConditionalsSource,
+			expression: `build.state == "started"`,
+			ctx: Context{
+				Build: Build{State: str("started")},
+			},
+			want: true,
+		},
+		{
 			name:       "enum comparison allows interpolated string literal",
 			source:     upstreamParserSpec,
 			expression: `build.state == "${STATE}"`,
@@ -234,6 +243,24 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			source:     upstreamBuildValidatorSpec,
 			expression: `build.fixed`,
 			wantError:  ErrorKindResult,
+		},
+		{
+			name:       "nullable context string fails inside array literal",
+			source:     upstreamBuildValidatorSpec,
+			expression: `[build.tag] includes "v1.0"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "nullable build env fails inside array literal",
+			source:     upstreamBuildValidatorSpec,
+			expression: `[build.env("MISSING")] includes "x"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "nullable shell expansion fails inside array literal",
+			source:     upstreamBuildValidatorSpec,
+			expression: `[${notset}] includes "x"`,
+			wantError:  ErrorKindValidation,
 		},
 		{
 			name:       "nullable ternary result fails closed",

--- a/eval_test.go
+++ b/eval_test.go
@@ -93,6 +93,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "valid enum comparison can put literal first",
+			source:     upstreamParserSpec,
+			expression: `"passed" == build.state`,
+			ctx: Context{
+				Build: Build{State: str("passed")},
+			},
+			want: true,
+		},
+		{
 			name:       "null includes string evaluates false",
 			source:     upstreamEvaluatorSpec,
 			expression: `null includes "fruit"`,
@@ -162,6 +171,12 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			name:       "non boolean result fails closed",
 			source:     upstreamBuildValidatorSpec,
 			expression: `"not boolean"`,
+			wantError:  ErrorKindResult,
+		},
+		{
+			name:       "nullable ternary result fails closed",
+			source:     upstreamParserSpec,
+			expression: `true ? null : true`,
 			wantError:  ErrorKindResult,
 		},
 	}
@@ -289,6 +304,13 @@ func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
 			name:       "double quoted strings interpolate shell variables",
 			source:     upstreamEvaluatorSpec,
 			expression: `"${branch}" == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "double quoted interpolation preserves backslashes",
+			source:     upstreamParserSpec,
+			expression: `"C:\\${branch}" == "C:\\main"`,
 			ctx:        ctx,
 			want:       true,
 		},

--- a/eval_test.go
+++ b/eval_test.go
@@ -102,6 +102,16 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "enum comparison allows interpolated string literal",
+			source:     upstreamParserSpec,
+			expression: `build.state == "${STATE}"`,
+			ctx: Context{
+				Build:    Build{State: str("passed")},
+				BuildEnv: map[string]string{"STATE": "passed"},
+			},
+			want: true,
+		},
+		{
 			name:       "valid enum comparison can put literal first",
 			source:     upstreamParserSpec,
 			expression: `"passed" == build.state`,
@@ -141,6 +151,18 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "logical and short-circuits missing variable validation",
+			source:     upstreamEvaluatorSpec,
+			expression: `false && missing.value == "x"`,
+			want:       false,
+		},
+		{
+			name:       "logical or short-circuits missing variable validation",
+			source:     upstreamEvaluatorSpec,
+			expression: `true || missing.value == "x"`,
+			want:       true,
+		},
+		{
 			name:       "nested precedence with and before or",
 			source:     upstreamParserSpec,
 			expression: `"a" == "d" || "a" == "b" && "a" == "a"`,
@@ -168,6 +190,13 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			name:       "nested ternary is right associative",
 			source:     upstreamEvaluatorSpec,
 			expression: `false ? true : false ? true : true`,
+			want:       true,
+		},
+		{
+			name:       "ternary array branch can feed includes",
+			source:     upstreamEvaluatorSpec,
+			expression: `(env("USE_CREATOR") == "true" ? build.creator.teams : ["deploy"]) includes "deploy"`,
+			ctx:        Context{BuildEnv: map[string]string{"USE_CREATOR": "false"}},
 			want:       true,
 		},
 		{
@@ -201,6 +230,12 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "nullable pull request boolean can be guarded before logical evaluation",
+			source:     docsConditionalsSource,
+			expression: `build.pull_request.draft != null && build.pull_request.draft`,
+			want:       false,
+		},
+		{
 			name:       "nullable pull request boolean fails before logical evaluation",
 			source:     docsConditionalsSource,
 			expression: `build.pull_request.draft || false`,
@@ -226,6 +261,13 @@ func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
 			name:       "bare shell variable",
 			source:     upstreamEvaluatorSpec,
 			expression: `$branch == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "bare shell variable preserves dotted suffix",
+			source:     upstreamEvaluatorSpec,
+			expression: `$branch.deploy == "main.deploy"`,
 			ctx:        ctx,
 			want:       true,
 		},

--- a/eval_test.go
+++ b/eval_test.go
@@ -93,6 +93,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "array literal accepts enum string variable",
+			source:     upstreamEvaluatorSpec,
+			expression: `[build.state] includes "passed"`,
+			ctx: Context{
+				Build: Build{State: str("passed")},
+			},
+			want: true,
+		},
+		{
 			name:       "documented started failing build state",
 			source:     docsConditionalsSource,
 			expression: `build.state == "started_failing"`,
@@ -251,6 +260,12 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "nullable pull request boolean can be coalesced with ternary",
+			source:     docsConditionalsSource,
+			expression: `build.pull_request.draft == null ? false : build.pull_request.draft`,
+			want:       false,
+		},
+		{
 			name:       "nullable pull request boolean fails before logical evaluation",
 			source:     docsConditionalsSource,
 			expression: `build.pull_request.draft || false`,
@@ -360,6 +375,13 @@ func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
 			name:       "substring offset only",
 			source:     upstreamEvaluatorSpec,
 			expression: `${branch:2} == "in"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring negative offset",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch: -1} == "n"`,
 			ctx:        ctx,
 			want:       true,
 		},

--- a/eval_test.go
+++ b/eval_test.go
@@ -189,6 +189,18 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			wantError:  ErrorKindResult,
 		},
 		{
+			name:       "nullable ternary alternative result fails closed",
+			source:     upstreamParserSpec,
+			expression: `false ? true : null`,
+			wantError:  ErrorKindResult,
+		},
+		{
+			name:       "nullable pull request boolean can be negated",
+			source:     docsConditionalsSource,
+			expression: `!build.pull_request.draft`,
+			want:       true,
+		},
+		{
 			name:       "nullable pull request boolean fails before logical evaluation",
 			source:     docsConditionalsSource,
 			expression: `build.pull_request.draft || false`,

--- a/eval_test.go
+++ b/eval_test.go
@@ -84,6 +84,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "documented started failing build state",
+			source:     docsConditionalsSource,
+			expression: `build.state == "started_failing"`,
+			ctx: Context{
+				Build: Build{State: str("started_failing")},
+			},
+			want: true,
+		},
+		{
 			name:       "null includes string evaluates false",
 			source:     upstreamEvaluatorSpec,
 			expression: `null includes "fruit"`,

--- a/eval_test.go
+++ b/eval_test.go
@@ -73,15 +73,44 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "logical and short-circuits false left side",
+			name:       "array includes regex",
 			source:     upstreamEvaluatorSpec,
-			expression: `false && missing.value == "x"`,
+			expression: `build.creator.teams includes /dep/`,
+			ctx: Context{
+				Build: Build{
+					Creator: Actor{Teams: []string{"deploy", "platform"}},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "null includes string evaluates false",
+			source:     upstreamEvaluatorSpec,
+			expression: `null includes "fruit"`,
 			want:       false,
 		},
 		{
-			name:       "logical or short-circuits true left side",
+			name:       "null regex match evaluates false",
 			source:     upstreamEvaluatorSpec,
-			expression: `true || missing.value == "x"`,
+			expression: `null =~ /main|development/`,
+			want:       false,
+		},
+		{
+			name:       "null regex non match evaluates true",
+			source:     upstreamEvaluatorSpec,
+			expression: `null !~ /main|development/`,
+			want:       true,
+		},
+		{
+			name:       "logical and short-circuits failing shell expansion",
+			source:     upstreamEvaluatorSpec,
+			expression: `false && ${notset:?} == "x"`,
+			want:       false,
+		},
+		{
+			name:       "logical or short-circuits failing shell expansion",
+			source:     upstreamEvaluatorSpec,
+			expression: `true || ${notset:?} == "x"`,
 			want:       true,
 		},
 		{
@@ -118,13 +147,155 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			name:       "missing variable fails closed",
 			source:     upstreamBuildConditionSpec,
 			expression: `missing.value == "x"`,
-			wantError:  ErrorKindEvaluation,
+			wantError:  ErrorKindValidation,
 		},
 		{
 			name:       "non boolean result fails closed",
 			source:     upstreamBuildValidatorSpec,
 			expression: `"not boolean"`,
 			wantError:  ErrorKindResult,
+		},
+	}
+
+	runEvaluateCases(t, tests)
+}
+
+func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
+	ctx := Context{
+		BuildEnv: map[string]string{
+			"branch": "main",
+			"empty":  "",
+			"tag":    "foo",
+			"two":    "2",
+		},
+	}
+
+	tests := []evaluateCase{
+		{
+			name:       "bare shell variable",
+			source:     upstreamEvaluatorSpec,
+			expression: `$branch == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "braced shell variable",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch} == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "unset shell variable is null",
+			source:     upstreamEvaluatorSpec,
+			expression: `${notset} == null`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "required unset shell variable fails",
+			source:     upstreamEvaluatorSpec,
+			expression: `${notset:?} == "error"`,
+			ctx:        ctx,
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "dash default uses set value",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch-xx} == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "dash default uses fallback for unset",
+			source:     upstreamEvaluatorSpec,
+			expression: `${notset-xx} == "xx"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "plus alternate uses alternate for set",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch+xx} == "xx"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "plus alternate returns empty for unset",
+			source:     upstreamEvaluatorSpec,
+			expression: `${notset+xx} == ""`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "colon dash treats empty as unset",
+			source:     upstreamEvaluatorSpec,
+			expression: `${empty:-xx} == "xx"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "colon plus treats empty as unset",
+			source:     upstreamEvaluatorSpec,
+			expression: `${empty:+xx} == ""`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring literal offsets",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:1:2} == "ai"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring variable length",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:2:$two} == "in"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring nested expressions",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:${empty:-1}:${two+2}} == "ai"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring past end returns empty",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:25:2} == ""`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring rejects non integer length",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:3:$tag} == "error"`,
+			ctx:        ctx,
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "double quoted strings interpolate shell variables",
+			source:     upstreamEvaluatorSpec,
+			expression: `"${branch}" == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "double dollar becomes literal dollar in double quoted strings",
+			source:     upstreamParserSpec,
+			expression: `"cost $$5" == "cost $5"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "single quoted strings do not interpolate shell variables",
+			source:     upstreamEvaluatorSpec,
+			expression: `'${branch}' == "main"`,
+			ctx:        ctx,
+			want:       false,
 		},
 	}
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -112,6 +112,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "enum comparison allows same enum variables",
+			source:     upstreamParserSpec,
+			expression: `build.state == build.state`,
+			ctx: Context{
+				Build: Build{State: str("passed")},
+			},
+			want: true,
+		},
+		{
 			name:       "valid enum comparison can put literal first",
 			source:     upstreamParserSpec,
 			expression: `"passed" == build.state`,
@@ -209,6 +218,12 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			name:       "non boolean result fails closed",
 			source:     upstreamBuildValidatorSpec,
 			expression: `"not boolean"`,
+			wantError:  ErrorKindResult,
+		},
+		{
+			name:       "nullable pointer backed boolean result fails closed",
+			source:     upstreamBuildValidatorSpec,
+			expression: `build.fixed`,
 			wantError:  ErrorKindResult,
 		},
 		{
@@ -338,6 +353,13 @@ func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
 			name:       "substring literal offsets",
 			source:     upstreamEvaluatorSpec,
 			expression: `${branch:1:2} == "ai"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "substring offset only",
+			source:     upstreamEvaluatorSpec,
+			expression: `${branch:2} == "in"`,
 			ctx:        ctx,
 			want:       true,
 		},

--- a/eval_test.go
+++ b/eval_test.go
@@ -84,6 +84,15 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "array includes enum string variable",
+			source:     docsConditionalsSource,
+			expression: `["passed", "failed"] includes build.state`,
+			ctx: Context{
+				Build: Build{State: str("passed")},
+			},
+			want: true,
+		},
+		{
 			name:       "documented started failing build state",
 			source:     docsConditionalsSource,
 			expression: `build.state == "started_failing"`,
@@ -178,6 +187,12 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			source:     upstreamParserSpec,
 			expression: `true ? null : true`,
 			wantError:  ErrorKindResult,
+		},
+		{
+			name:       "nullable pull request boolean fails before logical evaluation",
+			source:     docsConditionalsSource,
+			expression: `build.pull_request.draft || false`,
+			wantError:  ErrorKindValidation,
 		},
 	}
 

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -29,13 +29,13 @@ func Eval(node ast.Node, scope Scope) object.Object {
 		return &object.Integer{Value: node.Value}
 
 	case *ast.StringLiteral:
-		return &object.String{Value: node.Value}
+		return evalStringLiteral(node.Value, node.Token.Flags, scope)
 
 	case *ast.Regexp:
 		return &object.Regexp{Regexp: node.Regexp, Flags: node.Flags}
 
 	case *ast.ShellExpansion:
-		return newError("shell expansion evaluation is not implemented: %s", node.Raw)
+		return evalShellExpansion(node.Raw, scope)
 
 	case *ast.Boolean:
 		return nativeBoolToBooleanObject(node.Value)
@@ -158,8 +158,12 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 		return evalStringInfixExpression(operator, left, right)
 	case left.Type() == object.STRING_OBJ && right.Type() == object.REGEXP_OBJ:
 		return evalStringRegexpInfixExpression(operator, left, right)
+	case left.Type() == object.NULL_OBJ && right.Type() == object.REGEXP_OBJ:
+		return evalNullRegexpInfixExpression(operator, left, right)
 	case left.Type() == object.ARRAY_OBJ:
 		return evalArrayInfixExpression(operator, left, right)
+	case left.Type() == object.NULL_OBJ && operator == "includes":
+		return FALSE
 	case operator == "==":
 		return nativeBoolToBooleanObject(left.Type() == right.Type() && left.Equals(right))
 	case operator == "!=":
@@ -271,8 +275,42 @@ func evalStringRegexpInfixExpression(operator string, left, right object.Object)
 	}
 }
 
+func evalNullRegexpInfixExpression(operator string, left, right object.Object) object.Object {
+	switch operator {
+	case "=~":
+		return FALSE
+	case "!~":
+		return TRUE
+	default:
+		return newError("unknown operator: %s %s %s",
+			left.Type(), operator, right.Type())
+	}
+}
+
 func arrayContains(arr *object.Array, obj object.Object) (bool, error) {
 	// defer untrace(trace("arrayContains", arr, obj))
+
+	if _, ok := obj.(*object.Null); ok {
+		return false, nil
+	}
+
+	if regexpObj, ok := obj.(*object.Regexp); ok {
+		for idx, el := range arr.Elements {
+			stringObj, ok := el.(*object.String)
+			if !ok {
+				return false, fmt.Errorf("type mismatch at index %d in array: %s vs STRING",
+					idx, el.Type())
+			}
+			matched, err := regexpObj.MatchString(stringObj.Value)
+			if err != nil {
+				return false, fmt.Errorf("regexp match failed: %s", err)
+			}
+			if matched {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
 
 	for idx, el := range arr.Elements {
 		if el.Type() != obj.Type() {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -258,6 +258,11 @@ func TestConditionalExpression(t *testing.T) {
 	}
 }
 
+func TestDoubleQuotedShellExpansionWithoutEnvironmentScopeRemainsLiteral(t *testing.T) {
+	evaluated := testEval(`"${branch}" == "${branch}"`)
+	testBooleanObject(t, evaluated, true)
+}
+
 func testEval(input string) object.Object {
 	return testEvalWithScope(input, object.Struct{})
 }

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -57,17 +57,31 @@ func ContainsShellTemplate(value string) bool {
 // ContainsShellExpansion reports whether a string contains a shell expression
 // whose value depends on runtime environment.
 func ContainsShellExpansion(value string) bool {
-	for i := 0; i < len(value); i++ {
-		if value[i] != '$' {
-			continue
-		}
-		if i+1 < len(value) && value[i+1] == '$' {
+	for i := 0; i < len(value); {
+		switch value[i] {
+		case '$':
+			if i+1 < len(value) && value[i+1] == '$' {
+				i += 2
+				continue
+			}
+			_, _, ok := readShellExpansion(value, i)
+			if ok {
+				return true
+			}
+			i++
+		case '\\':
+			next := i
+			for next < len(value) && value[next] == '\\' {
+				next++
+			}
+			if next < len(value) && value[next] == '$' && next == i+1 {
+				i = next + 1
+				continue
+			}
+			i = next
+		default:
 			i++
 			continue
-		}
-		_, _, ok := readShellExpansion(value, i)
-		if ok {
-			return true
 		}
 	}
 	return false

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -9,7 +9,7 @@ import (
 	"github.com/buildkite/conditional/object"
 )
 
-var shellIntegerPattern = regexp.MustCompile(`^[0-9]+$`)
+var shellIntegerPattern = regexp.MustCompile(`^-?[0-9]+$`)
 
 type EnvScope interface {
 	LookupEnv(key string) (string, bool)
@@ -163,6 +163,12 @@ func evalShellSubstring(name string, raw string, env EnvScope) (string, bool, er
 	}
 
 	runes := []rune(base)
+	if x < 0 {
+		x = len(runes) + x
+	}
+	if x < 0 {
+		x = 0
+	}
 	if x >= len(runes) {
 		return "", true, nil
 	}
@@ -172,10 +178,17 @@ func evalShellSubstring(name string, raw string, env EnvScope) (string, bool, er
 		if err != nil {
 			return "", false, err
 		}
-		end = x + y
+		if y < 0 {
+			end = len(runes) + y
+		} else {
+			end = x + y
+		}
 	}
 	if end > len(runes) {
 		end = len(runes)
+	}
+	if end < x {
+		end = x
 	}
 	return string(runes[x:end]), true, nil
 }
@@ -185,6 +198,7 @@ func evalShellInteger(raw string, env EnvScope) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	value = strings.TrimSpace(value)
 	if !shellIntegerPattern.MatchString(value) {
 		return 0, fmt.Errorf("substring operation requires integer argument, not %q", value)
 	}

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -32,7 +32,7 @@ func evalShellExpansion(raw string, scope Scope) object.Object {
 }
 
 func evalStringLiteral(value string, quote string, scope Scope) object.Object {
-	if quote != `"` || !containsShellTemplate(value) {
+	if quote != `"` || !ContainsShellTemplate(value) {
 		return &object.String{Value: value}
 	}
 
@@ -48,7 +48,9 @@ func evalStringLiteral(value string, quote string, scope Scope) object.Object {
 	return &object.String{Value: out}
 }
 
-func containsShellTemplate(value string) bool {
+// ContainsShellTemplate reports whether a double-quoted string can produce a
+// different runtime value after shell-style expansion.
+func ContainsShellTemplate(value string) bool {
 	return strings.Contains(value, "$$") || containsShellExpansion(value)
 }
 
@@ -70,8 +72,17 @@ func evalShellRaw(raw string, env EnvScope) (string, bool, error) {
 		return evalBracedShell(raw[2:len(raw)-1], env)
 	}
 	if strings.HasPrefix(raw, "$") {
-		name := raw[1:]
+		name, rest, ok := splitShellName(raw[1:])
+		if !ok {
+			return "", false, fmt.Errorf("invalid shell expansion: %s", raw)
+		}
 		value, ok := env.LookupEnv(name)
+		if rest != "" {
+			if !ok {
+				value = ""
+			}
+			return value + rest, true, nil
+		}
 		return value, ok, nil
 	}
 	return "", false, fmt.Errorf("invalid shell expansion: %s", raw)

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -1,0 +1,322 @@
+package evaluator
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/conditional/object"
+)
+
+var shellIntegerPattern = regexp.MustCompile(`^[0-9]+$`)
+
+type EnvScope interface {
+	LookupEnv(key string) (string, bool)
+}
+
+func evalShellExpansion(raw string, scope Scope) object.Object {
+	env, ok := scope.(EnvScope)
+	if !ok {
+		return newError("shell expansion evaluation requires environment scope")
+	}
+
+	value, set, err := evalShellRaw(raw, env)
+	if err != nil {
+		return newError("%s", err.Error())
+	}
+	if !set {
+		return NULL
+	}
+	return &object.String{Value: value}
+}
+
+func evalStringLiteral(value string, quote string, scope Scope) object.Object {
+	if quote != `"` || !containsShellTemplate(value) {
+		return &object.String{Value: value}
+	}
+
+	env, ok := scope.(EnvScope)
+	if !ok {
+		return &object.String{Value: value}
+	}
+
+	out, err := evalShellString(value, env)
+	if err != nil {
+		return newError("%s", err.Error())
+	}
+	return &object.String{Value: out}
+}
+
+func containsShellTemplate(value string) bool {
+	return strings.Contains(value, "$$") || containsShellExpansion(value)
+}
+
+func containsShellExpansion(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] != '$' {
+			continue
+		}
+		_, _, ok := readShellExpansion(value, i)
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func evalShellRaw(raw string, env EnvScope) (string, bool, error) {
+	if strings.HasPrefix(raw, "${") && strings.HasSuffix(raw, "}") {
+		return evalBracedShell(raw[2:len(raw)-1], env)
+	}
+	if strings.HasPrefix(raw, "$") {
+		name := raw[1:]
+		value, ok := env.LookupEnv(name)
+		return value, ok, nil
+	}
+	return "", false, fmt.Errorf("invalid shell expansion: %s", raw)
+}
+
+func evalBracedShell(inner string, env EnvScope) (string, bool, error) {
+	name, rest, ok := splitShellName(inner)
+	if !ok {
+		return "", false, fmt.Errorf("invalid shell expansion: ${%s}", inner)
+	}
+
+	if rest == "" {
+		value, ok := env.LookupEnv(name)
+		return value, ok, nil
+	}
+
+	if strings.HasPrefix(rest, ":") && !strings.HasPrefix(rest, ":-") && !strings.HasPrefix(rest, ":+") && !strings.HasPrefix(rest, ":?") {
+		return evalShellSubstring(name, rest[1:], env)
+	}
+
+	operator, valueRaw, ok := splitShellOperator(rest)
+	if !ok {
+		return "", false, fmt.Errorf("invalid shell expansion: ${%s}", inner)
+	}
+
+	base, set := env.LookupEnv(name)
+	op := operator
+	if strings.HasPrefix(op, ":") {
+		op = op[1:]
+		if set && base == "" {
+			set = false
+		}
+	}
+
+	switch op {
+	case "?":
+		if set {
+			return base, true, nil
+		}
+		return "", false, fmt.Errorf("parameter null or not set: %s", name)
+	case "+":
+		if !set {
+			return "", true, nil
+		}
+		value, err := evalShellString(valueRaw, env)
+		return value, true, err
+	case "-":
+		if set {
+			return base, true, nil
+		}
+		value, err := evalShellString(valueRaw, env)
+		return value, true, err
+	default:
+		return "", false, fmt.Errorf("invalid shell operator: %s", operator)
+	}
+}
+
+func evalShellSubstring(name string, raw string, env EnvScope) (string, bool, error) {
+	parts := splitTopLevel(raw, ':')
+	if len(parts) != 2 {
+		return "", false, fmt.Errorf("invalid shell substring: %s", raw)
+	}
+
+	x, err := evalShellInteger(parts[0], env)
+	if err != nil {
+		return "", false, err
+	}
+	y, err := evalShellInteger(parts[1], env)
+	if err != nil {
+		return "", false, err
+	}
+
+	base, ok := env.LookupEnv(name)
+	if !ok {
+		return "", false, nil
+	}
+
+	runes := []rune(base)
+	if x >= len(runes) {
+		return "", true, nil
+	}
+	end := x + y
+	if end > len(runes) {
+		end = len(runes)
+	}
+	return string(runes[x:end]), true, nil
+}
+
+func evalShellInteger(raw string, env EnvScope) (int, error) {
+	value, err := evalShellString(raw, env)
+	if err != nil {
+		return 0, err
+	}
+	if !shellIntegerPattern.MatchString(value) {
+		return 0, fmt.Errorf("substring operation requires integer argument, not %q", value)
+	}
+	return strconv.Atoi(value)
+}
+
+func evalShellString(raw string, env EnvScope) (string, error) {
+	var out strings.Builder
+	for i := 0; i < len(raw); {
+		switch raw[i] {
+		case '$':
+			if i+1 < len(raw) && raw[i+1] == '$' {
+				out.WriteByte('$')
+				i += 2
+				continue
+			}
+			expansion, next, ok := readShellExpansion(raw, i)
+			if !ok {
+				out.WriteByte('$')
+				i++
+				continue
+			}
+			value, set, err := evalShellRaw(expansion, env)
+			if err != nil {
+				return "", err
+			}
+			if set {
+				out.WriteString(value)
+			}
+			i = next
+		case '\\':
+			value, next := readShellEscape(raw, i)
+			out.WriteString(value)
+			i = next
+		default:
+			out.WriteByte(raw[i])
+			i++
+		}
+	}
+	return out.String(), nil
+}
+
+func splitShellName(inner string) (name string, rest string, ok bool) {
+	if inner == "" || !isShellIdentStart(inner[0]) {
+		return "", "", false
+	}
+	i := 1
+	for i < len(inner) && isShellIdentPart(inner[i]) {
+		i++
+	}
+	return inner[:i], inner[i:], true
+}
+
+func splitShellOperator(rest string) (operator string, value string, ok bool) {
+	for _, op := range []string{":?", ":+", ":-", "?", "+", "-"} {
+		if strings.HasPrefix(rest, op) {
+			return op, rest[len(op):], true
+		}
+	}
+	return "", "", false
+}
+
+func splitTopLevel(raw string, separator byte) []string {
+	parts := []string{}
+	start := 0
+	depth := 0
+	for i := 0; i < len(raw); i++ {
+		if raw[i] == '$' && i+1 < len(raw) && raw[i+1] == '{' {
+			depth++
+			i++
+			continue
+		}
+		if raw[i] == '}' && depth > 0 {
+			depth--
+			continue
+		}
+		if raw[i] == separator && depth == 0 {
+			parts = append(parts, raw[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, raw[start:])
+	return parts
+}
+
+func readShellExpansion(raw string, start int) (string, int, bool) {
+	if start+1 >= len(raw) {
+		return "", start, false
+	}
+	if raw[start+1] == '$' {
+		return "$$", start + 2, false
+	}
+	if isShellIdentStart(raw[start+1]) {
+		i := start + 2
+		for i < len(raw) && isShellIdentPart(raw[i]) {
+			i++
+		}
+		return raw[start:i], i, true
+	}
+	if raw[start+1] != '{' {
+		return "", start, false
+	}
+
+	depth := 1
+	for i := start + 2; i < len(raw); i++ {
+		if raw[i] == '$' && i+1 < len(raw) && raw[i+1] == '{' {
+			depth++
+			i++
+			continue
+		}
+		if raw[i] == '}' {
+			depth--
+			if depth == 0 {
+				return raw[start : i+1], i + 1, true
+			}
+		}
+	}
+	return "", start, false
+}
+
+func readShellEscape(raw string, start int) (string, int) {
+	if start+1 >= len(raw) {
+		return "", start + 1
+	}
+	switch raw[start+1] {
+	case 'n':
+		return "\n", start + 2
+	case 's':
+		return " ", start + 2
+	case 'r':
+		return "\r", start + 2
+	case 't':
+		return "\t", start + 2
+	case 'v':
+		return "\v", start + 2
+	case 'f':
+		return "\f", start + 2
+	case 'b':
+		return "\b", start + 2
+	case 'a':
+		return "\a", start + 2
+	case 'e':
+		return "\x1b", start + 2
+	default:
+		return string(raw[start+1]), start + 2
+	}
+}
+
+func isShellIdentStart(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isShellIdentPart(ch byte) bool {
+	return isShellIdentStart(ch) || (ch >= '0' && ch <= '9')
+}

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -196,8 +196,16 @@ func evalShellString(raw string, env EnvScope) (string, error) {
 			}
 			i = next
 		case '\\':
-			value, next := readShellEscape(raw, i)
-			out.WriteString(value)
+			next := i
+			for next < len(raw) && raw[next] == '\\' {
+				next++
+			}
+			if next < len(raw) && raw[next] == '$' && next == i+1 {
+				out.WriteByte('$')
+				i = next + 1
+				continue
+			}
+			out.WriteString(raw[i:next])
 			i = next
 		default:
 			out.WriteByte(raw[i])
@@ -283,34 +291,6 @@ func readShellExpansion(raw string, start int) (string, int, bool) {
 		}
 	}
 	return "", start, false
-}
-
-func readShellEscape(raw string, start int) (string, int) {
-	if start+1 >= len(raw) {
-		return "", start + 1
-	}
-	switch raw[start+1] {
-	case 'n':
-		return "\n", start + 2
-	case 's':
-		return " ", start + 2
-	case 'r':
-		return "\r", start + 2
-	case 't':
-		return "\t", start + 2
-	case 'v':
-		return "\v", start + 2
-	case 'f':
-		return "\f", start + 2
-	case 'b':
-		return "\b", start + 2
-	case 'a':
-		return "\a", start + 2
-	case 'e':
-		return "\x1b", start + 2
-	default:
-		return string(raw[start+1]), start + 2
-	}
 }
 
 func isShellIdentStart(ch byte) bool {

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -51,12 +51,18 @@ func evalStringLiteral(value string, quote string, scope Scope) object.Object {
 // ContainsShellTemplate reports whether a double-quoted string can produce a
 // different runtime value after shell-style expansion.
 func ContainsShellTemplate(value string) bool {
-	return strings.Contains(value, "$$") || containsShellExpansion(value)
+	return strings.Contains(value, "$$") || ContainsShellExpansion(value)
 }
 
-func containsShellExpansion(value string) bool {
+// ContainsShellExpansion reports whether a string contains a shell expression
+// whose value depends on runtime environment.
+func ContainsShellExpansion(value string) bool {
 	for i := 0; i < len(value); i++ {
 		if value[i] != '$' {
+			continue
+		}
+		if i+1 < len(value) && value[i+1] == '$' {
+			i++
 			continue
 		}
 		_, _, ok := readShellExpansion(value, i)
@@ -142,15 +148,11 @@ func evalBracedShell(inner string, env EnvScope) (string, bool, error) {
 
 func evalShellSubstring(name string, raw string, env EnvScope) (string, bool, error) {
 	parts := splitTopLevel(raw, ':')
-	if len(parts) != 2 {
+	if len(parts) < 1 || len(parts) > 2 {
 		return "", false, fmt.Errorf("invalid shell substring: %s", raw)
 	}
 
 	x, err := evalShellInteger(parts[0], env)
-	if err != nil {
-		return "", false, err
-	}
-	y, err := evalShellInteger(parts[1], env)
 	if err != nil {
 		return "", false, err
 	}
@@ -164,7 +166,14 @@ func evalShellSubstring(name string, raw string, env EnvScope) (string, bool, er
 	if x >= len(runes) {
 		return "", true, nil
 	}
-	end := x + y
+	end := len(runes)
+	if len(parts) == 2 {
+		y, err := evalShellInteger(parts[1], env)
+		if err != nil {
+			return "", false, err
+		}
+		end = x + y
+	}
 	if end > len(runes) {
 		end = len(runes)
 	}

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -130,6 +130,12 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindValidation,
 		},
 		{
+			name:       "validation rejects env escaped dollar name",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("$$FOO") == ""`,
+			wantError:  ErrorKindValidation,
+		},
+		{
 			name:       "validation rejects unknown variable",
 			source:     upstreamParserSpec,
 			expression: `not_a_variable == "x"`,

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -184,6 +184,18 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindValidation,
 		},
 		{
+			name:       "validation rejects null array equality",
+			source:     upstreamParserSpec,
+			expression: `null == ["a"]`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects null array variable equality",
+			source:     upstreamParserSpec,
+			expression: `null == build.creator.teams`,
+			wantError:  ErrorKindValidation,
+		},
+		{
 			name:       "validation rejects invalid enum literal",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.state == "faillled"`,

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -172,6 +172,18 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindValidation,
 		},
 		{
+			name:       "validation rejects array equality",
+			source:     upstreamParserSpec,
+			expression: `["a"] == ["a"]`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects array null equality",
+			source:     upstreamParserSpec,
+			expression: `["a"] == null`,
+			wantError:  ErrorKindValidation,
+		},
+		{
 			name:       "validation rejects invalid enum literal",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.state == "faillled"`,

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -177,6 +177,24 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			expression: `build.state == "faillled"`,
 			wantError:  ErrorKindValidation,
 		},
+		{
+			name:       "validation rejects reversed enum comparison",
+			source:     upstreamParserSpec,
+			expression: `"faillled" == build.state`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects enum in string regex position",
+			source:     upstreamParserSpec,
+			expression: `build.state =~ /pass/`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects ternary branch type mismatch",
+			source:     upstreamParserSpec,
+			expression: `(true ? "string" : 123) == null`,
+			wantError:  ErrorKindValidation,
+		},
 	}
 
 	runValidateCases(t, tests)

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -123,6 +123,60 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			expression: `build.env("FOO", "BAR") == null`,
 			wantError:  ErrorKindValidation,
 		},
+		{
+			name:       "validation rejects env non string argument",
+			source:     upstreamParserSpec,
+			expression: `env(1) == ""`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects unknown variable",
+			source:     upstreamParserSpec,
+			expression: `not_a_variable == "x"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects unknown function",
+			source:     upstreamParserSpec,
+			expression: `not_a_function() == "x"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects regex with non regexp rhs",
+			source:     upstreamParserSpec,
+			expression: `"d" =~ "hello"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects regex with boolean lhs",
+			source:     upstreamParserSpec,
+			expression: `true =~ /true/`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects mismatched equality types",
+			source:     upstreamParserSpec,
+			expression: `1 == "one"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects boolean string comparison",
+			source:     upstreamParserSpec,
+			expression: `true == "true"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects includes on non array",
+			source:     upstreamParserSpec,
+			expression: `"not-an-array" includes "one"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects invalid enum literal",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.state == "faillled"`,
+			wantError:  ErrorKindValidation,
+		},
 	}
 
 	runValidateCases(t, tests)

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -136,6 +136,12 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindValidation,
 		},
 		{
+			name:       "validation rejects env backslash escaped dollar name",
+			source:     upstreamBuildConditionSpec,
+			expression: `env("\$FOO") == ""`,
+			wantError:  ErrorKindValidation,
+		},
+		{
 			name:       "validation rejects unknown variable",
 			source:     upstreamParserSpec,
 			expression: `not_a_variable == "x"`,

--- a/typecheck.go
+++ b/typecheck.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/buildkite/conditional/ast"
+	"github.com/buildkite/conditional/evaluator"
 )
 
 type valueKind string
@@ -126,7 +127,14 @@ func (c typeChecker) checkInfix(expr *ast.InfixExpression) (valueType, error) {
 		if err := c.expect(expr.Left, kindBool); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
-		if err := c.expect(expr.Right, kindBool); err != nil {
+		if logicalExpressionShortCircuits(expr) {
+			return valueType{kind: kindBool}, nil
+		}
+		rightChecker := c
+		if name, ok := nonNullGuardForRHS(expr.Operator, expr.Left); ok {
+			rightChecker = c.withNonNullableVariable(name)
+		}
+		if err := rightChecker.expect(expr.Right, kindBool); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -144,7 +152,7 @@ func (c typeChecker) checkConditional(expr *ast.ConditionalExpression) (valueTyp
 	if err := c.expect(expr.Condition, kindBool); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	return c.checkComparisonTypes(expr.Consequence, expr.Alternative)
+	return c.checkCompatibleTypes(expr.Consequence, expr.Alternative, true)
 }
 
 func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
@@ -169,6 +177,10 @@ func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
 }
 
 func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType, error) {
+	return c.checkCompatibleTypes(left, right, false)
+}
+
+func (c typeChecker) checkCompatibleTypes(left, right ast.Expression, allowArrays bool) (valueType, error) {
 	leftType, err := c.check(left)
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
@@ -178,10 +190,10 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	if leftType.kind == kindStringArray {
+	if !allowArrays && leftType.kind == kindStringArray {
 		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", leftType.describe())
 	}
-	if rightType.kind == kindStringArray {
+	if !allowArrays && rightType.kind == kindStringArray {
 		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", rightType.describe())
 	}
 	if leftType.kind == kindNull || leftType.kind == kindUnknown {
@@ -190,18 +202,24 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 	if rightType.kind == kindNull || rightType.kind == kindUnknown {
 		return leftType.withNull(), nil
 	}
+	if leftType.kind == kindStringArray || rightType.kind == kindStringArray {
+		if leftType.kind != rightType.kind {
+			return valueType{kind: kindUnknown}, validationError("unexpected type: expected %s but found %s", leftType.describe(), rightType.describe())
+		}
+		return leftType.withNullabilityFrom(rightType), nil
+	}
 	if leftType.enum != nil {
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
-		if literal, ok := right.(*ast.StringLiteral); ok && !leftType.enum.includes(literal.Value) {
+		if literal, ok := staticStringLiteral(right); ok && !leftType.enum.includes(literal.Value) {
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
 		}
 		return leftType.withNullabilityFrom(rightType), nil
 	}
 
 	if rightType.enum != nil && leftType.kind == kindString {
-		if literal, ok := left.(*ast.StringLiteral); ok && !rightType.enum.includes(literal.Value) {
+		if literal, ok := staticStringLiteral(left); ok && !rightType.enum.includes(literal.Value) {
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(right))
 		}
 		return rightType.withNullabilityFrom(leftType), nil
@@ -211,6 +229,22 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 		return valueType{kind: kindUnknown}, err
 	}
 	return leftType.withNullabilityFrom(rightType), nil
+}
+
+func (c typeChecker) withNonNullableVariable(name string) typeChecker {
+	typ, ok := c.variables[name]
+	if !ok || !typ.nullable {
+		return c
+	}
+
+	variables := make(map[string]valueType, len(c.variables))
+	for key, value := range c.variables {
+		variables[key] = value
+	}
+	typ.nullable = false
+	variables[name] = typ
+	c.variables = variables
+	return c
 }
 
 func (c typeChecker) expect(expr ast.Expression, expected valueKind) error {
@@ -427,6 +461,56 @@ func containsKind(kinds []valueKind, target valueKind) bool {
 		}
 	}
 	return false
+}
+
+func runtimeStringLiteral(literal *ast.StringLiteral) bool {
+	return literal.Token.Flags == `"` && evaluator.ContainsShellTemplate(literal.Value)
+}
+
+func staticStringLiteral(expr ast.Expression) (*ast.StringLiteral, bool) {
+	literal, ok := expr.(*ast.StringLiteral)
+	if !ok || runtimeStringLiteral(literal) {
+		return nil, false
+	}
+	return literal, true
+}
+
+func logicalExpressionShortCircuits(expr *ast.InfixExpression) bool {
+	left, ok := expr.Left.(*ast.Boolean)
+	if !ok {
+		return false
+	}
+
+	return (expr.Operator == "&&" && !left.Value) || (expr.Operator == "||" && left.Value)
+}
+
+func nonNullGuardForRHS(operator string, left ast.Expression) (string, bool) {
+	guard, ok := left.(*ast.InfixExpression)
+	if !ok {
+		return "", false
+	}
+	switch {
+	case operator == "&&" && guard.Operator == "!=":
+		return nullComparedIdentifier(guard.Left, guard.Right)
+	case operator == "||" && guard.Operator == "==":
+		return nullComparedIdentifier(guard.Left, guard.Right)
+	default:
+		return "", false
+	}
+}
+
+func nullComparedIdentifier(left, right ast.Expression) (string, bool) {
+	if _, ok := right.(*ast.Null); ok {
+		if ident, ok := left.(*ast.Identifier); ok {
+			return ident.Value, true
+		}
+	}
+	if _, ok := left.(*ast.Null); ok {
+		if ident, ok := right.(*ast.Identifier); ok {
+			return ident.Value, true
+		}
+	}
+	return "", false
 }
 
 func identifierName(expr ast.Expression) string {

--- a/typecheck.go
+++ b/typecheck.go
@@ -130,7 +130,7 @@ func (c typeChecker) checkInfix(expr *ast.InfixExpression) (valueType, error) {
 		}
 		return valueType{kind: kindBool}, nil
 	case "==", "!=":
-		if err := c.checkComparisonTypes(expr.Left, expr.Right); err != nil {
+		if _, err := c.checkComparisonTypes(expr.Left, expr.Right); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -143,10 +143,7 @@ func (c typeChecker) checkConditional(expr *ast.ConditionalExpression) (valueTyp
 	if err := c.expect(expr.Condition, kindBool); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	if err := c.checkComparisonTypes(expr.Consequence, expr.Alternative); err != nil {
-		return valueType{kind: kindUnknown}, err
-	}
-	return c.check(expr.Consequence)
+	return c.checkComparisonTypes(expr.Consequence, expr.Alternative)
 }
 
 func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
@@ -170,28 +167,30 @@ func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
 	return signature.ret, nil
 }
 
-func (c typeChecker) checkComparisonTypes(left, right ast.Expression) error {
+func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType, error) {
 	leftType, err := c.check(left)
 	if err != nil {
-		return err
+		return valueType{kind: kindUnknown}, err
 	}
 
 	if leftType.kind == kindNull || leftType.kind == kindUnknown {
-		_, err := c.check(right)
-		return err
+		return c.check(right)
 	}
 
 	if leftType.enum != nil {
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
-			return err
+			return valueType{kind: kindUnknown}, err
 		}
 		if literal, ok := right.(*ast.StringLiteral); ok && !leftType.enum.includes(literal.Value) {
-			return validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
+			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
 		}
-		return nil
+		return leftType, nil
 	}
 
-	return c.expectAny(right, leftType.kind, kindNull)
+	if err := c.expectAny(right, leftType.kind, kindNull); err != nil {
+		return valueType{kind: kindUnknown}, err
+	}
+	return leftType, nil
 }
 
 func (c typeChecker) expect(expr ast.Expression, expected valueKind) error {
@@ -218,7 +217,7 @@ func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error
 func variableTypes(entryPoint EntryPoint) map[string]valueType {
 	variables := map[string]valueType{
 		"build.id":                            stringType(),
-		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "canceling", "canceled", "skipped", "not_run"),
+		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
 		"build.fixed":                         boolType(),
 		"build.blocked_state":                 enumValueType("build blocked state", "failed", "passed", "running"),
 		"build.source":                        enumValueType("build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),

--- a/typecheck.go
+++ b/typecheck.go
@@ -41,7 +41,7 @@ type typeChecker struct {
 
 func typeCheckExpression(expr ast.Expression, ctx Context) error {
 	checker := typeChecker{
-		variables: variableTypes(ctx.EntryPoint),
+		variables: variableTypes(ctx),
 		functions: functionTypes(),
 	}
 
@@ -118,7 +118,7 @@ func (c typeChecker) checkInfix(expr *ast.InfixExpression) (valueType, error) {
 		if err := c.expectAny(expr.Left, kindStringArray, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
-		if err := c.expectAny(expr.Right, kindString, kindRegexp, kindNull); err != nil {
+		if err := c.expectIncludesRight(expr.Right); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -178,6 +178,9 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 		rightType, err := c.check(right)
 		return rightType.withNull(), err
 	}
+	if leftType.kind == kindStringArray {
+		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", leftType.describe())
+	}
 
 	if leftType.enum != nil {
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
@@ -198,6 +201,9 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(right))
 		}
 		return rightType, nil
+	}
+	if rightType.kind == kindStringArray {
+		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", rightType.describe())
 	}
 
 	if err := c.expectAny(right, leftType.kind, kindNull); err != nil {
@@ -231,7 +237,22 @@ func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error
 	return validationError("unexpected type: expected %s but found %s", describeKinds(expected), actual.describe())
 }
 
-func variableTypes(entryPoint EntryPoint) map[string]valueType {
+func (c typeChecker) expectIncludesRight(expr ast.Expression) error {
+	actual, err := c.check(expr)
+	if err != nil {
+		return err
+	}
+	if actual.kind == kindUnknown {
+		return nil
+	}
+	switch actual.kind {
+	case kindString, kindRegexp, kindNull:
+		return nil
+	}
+	return validationError("unexpected type: expected string, regular expression, or null but found %s", actual.describe())
+}
+
+func variableTypes(ctx Context) map[string]valueType {
 	variables := map[string]valueType{
 		"build.id":                            stringType(),
 		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
@@ -260,11 +281,11 @@ func variableTypes(entryPoint EntryPoint) map[string]valueType {
 		"build.scm.committer.email":           stringType(),
 		"build.pull_request.id":               stringType(),
 		"build.pull_request.base_branch":      stringType(),
-		"build.pull_request.draft":            boolType(),
+		"build.pull_request.draft":            boolTypeFor(ctx.Build.PullRequest.Draft),
 		"build.pull_request.label":            stringType(),
 		"build.pull_request.labels":           stringArrayType(),
 		"build.pull_request.repository":       stringType(),
-		"build.pull_request.repository.fork":  boolType(),
+		"build.pull_request.repository.fork":  boolTypeFor(ctx.Build.PullRequest.RepositoryFork),
 		"build.merge_queue.base_branch":       stringType(),
 		"build.merge_queue.base_commit":       stringType(),
 		"pipeline.id":                         stringType(),
@@ -279,7 +300,7 @@ func variableTypes(entryPoint EntryPoint) map[string]valueType {
 		"organization.slug":                   stringType(),
 	}
 
-	if stepAllowed(entryPoint) {
+	if stepAllowed(ctx.EntryPoint) {
 		variables["step.id"] = stringType()
 		variables["step.key"] = stringType()
 		variables["step.type"] = enumValueType("step type", "command", "wait", "input", "trigger", "group")
@@ -314,6 +335,17 @@ func numberType() valueType {
 
 func boolType() valueType {
 	return valueType{kind: kindBool}
+}
+
+func nullableBoolType() valueType {
+	return valueType{kind: kindBool, nullable: true}
+}
+
+func boolTypeFor(value *bool) valueType {
+	if value == nil {
+		return nullableBoolType()
+	}
+	return boolType()
 }
 
 func stringArrayType() valueType {

--- a/typecheck.go
+++ b/typecheck.go
@@ -24,8 +24,9 @@ type enumType struct {
 }
 
 type valueType struct {
-	kind valueKind
-	enum *enumType
+	kind     valueKind
+	enum     *enumType
+	nullable bool
 }
 
 type functionSignature struct {
@@ -48,7 +49,7 @@ func typeCheckExpression(expr ast.Expression, ctx Context) error {
 	if err != nil {
 		return err
 	}
-	if got.kind != kindBool && got.kind != kindUnknown {
+	if (got.kind != kindBool && got.kind != kindUnknown) || got.nullable {
 		return &Error{
 			Kind:    ErrorKindResult,
 			Message: fmt.Sprintf("expected boolean result, got %s", got.describe()),
@@ -174,7 +175,8 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 	}
 
 	if leftType.kind == kindNull || leftType.kind == kindUnknown {
-		return c.check(right)
+		rightType, err := c.check(right)
+		return rightType.withNull(), err
 	}
 
 	if leftType.enum != nil {
@@ -185,6 +187,17 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
 		}
 		return leftType, nil
+	}
+
+	rightType, err := c.check(right)
+	if err != nil {
+		return valueType{kind: kindUnknown}, err
+	}
+	if rightType.enum != nil && leftType.kind == kindString {
+		if literal, ok := left.(*ast.StringLiteral); ok && !rightType.enum.includes(literal.Value) {
+			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(right))
+		}
+		return rightType, nil
 	}
 
 	if err := c.expectAny(right, leftType.kind, kindNull); err != nil {
@@ -205,8 +218,12 @@ func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error
 	if actual.kind == kindUnknown {
 		return nil
 	}
+	allowsNull := containsKind(expected, kindNull)
 	for _, expectedKind := range expected {
 		if actual.enum == nil && actual.kind == expectedKind {
+			if actual.nullable && !allowsNull {
+				continue
+			}
 			return nil
 		}
 	}
@@ -316,9 +333,23 @@ func enumValueType(name string, values ...string) valueType {
 
 func (t valueType) describe() string {
 	if t.enum != nil {
+		if t.nullable {
+			return "nullable " + t.enum.name + " enumeration value"
+		}
 		return t.enum.name + " enumeration value"
 	}
+	if t.nullable {
+		return "nullable " + string(t.kind)
+	}
 	return string(t.kind)
+}
+
+func (t valueType) withNull() valueType {
+	if t.kind == kindUnknown {
+		return t
+	}
+	t.nullable = true
+	return t
 }
 
 func (e enumType) includes(value string) bool {
@@ -347,6 +378,15 @@ func describeKinds(kinds []valueKind) string {
 		}
 	}
 	return out
+}
+
+func containsKind(kinds []valueKind, target valueKind) bool {
+	for _, kind := range kinds {
+		if kind == target {
+			return true
+		}
+	}
+	return false
 }
 
 func identifierName(expr ast.Expression) string {

--- a/typecheck.go
+++ b/typecheck.go
@@ -209,6 +209,12 @@ func (c typeChecker) checkCompatibleTypes(left, right ast.Expression, allowArray
 		return leftType.withNullabilityFrom(rightType), nil
 	}
 	if leftType.enum != nil {
+		if rightType.enum != nil {
+			if !leftType.enum.compatible(rightType.enum) {
+				return valueType{kind: kindUnknown}, validationError("unexpected type: expected %s but found %s", leftType.describe(), rightType.describe())
+			}
+			return leftType.withNullabilityFrom(rightType), nil
+		}
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
@@ -291,7 +297,7 @@ func variableTypes(ctx Context) map[string]valueType {
 	variables := map[string]valueType{
 		"build.id":                            stringType(),
 		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
-		"build.fixed":                         boolType(),
+		"build.fixed":                         boolTypeFor(ctx.Build.Fixed),
 		"build.blocked_state":                 enumValueType("build blocked state", "failed", "passed", "running"),
 		"build.source":                        enumValueType("build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),
 		"build.source_event":                  stringType(),
@@ -305,7 +311,7 @@ func variableTypes(ctx Context) map[string]valueType {
 		"build.creator.name":                  stringType(),
 		"build.creator.email":                 stringType(),
 		"build.creator.teams":                 stringArrayType(),
-		"build.creator.verified":              boolType(),
+		"build.creator.verified":              boolTypeFor(ctx.Build.Creator.Verified),
 		"build.author.id":                     stringType(),
 		"build.author.name":                   stringType(),
 		"build.author.email":                  stringType(),
@@ -328,9 +334,9 @@ func variableTypes(ctx Context) map[string]valueType {
 		"pipeline.slug":                       stringType(),
 		"pipeline.default_branch":             stringType(),
 		"pipeline.repository":                 stringType(),
-		"pipeline.started_passing":            boolType(),
-		"pipeline.started_failing":            boolType(),
-		"pipeline.next_finished_build_exists": boolType(),
+		"pipeline.started_passing":            boolTypeFor(ctx.Pipeline.StartedPassing),
+		"pipeline.started_failing":            boolTypeFor(ctx.Pipeline.StartedFailing),
+		"pipeline.next_finished_build_exists": boolTypeFor(ctx.Pipeline.NextFinishedBuildExists),
 		"organization.id":                     stringType(),
 		"organization.slug":                   stringType(),
 	}
@@ -431,6 +437,10 @@ func (e enumType) includes(value string) bool {
 	return ok
 }
 
+func (e enumType) compatible(other *enumType) bool {
+	return other != nil && e.name == other.name
+}
+
 func validationError(format string, args ...any) *Error {
 	return &Error{Kind: ErrorKindValidation, Message: fmt.Sprintf(format, args...)}
 }
@@ -464,7 +474,7 @@ func containsKind(kinds []valueKind, target valueKind) bool {
 }
 
 func runtimeStringLiteral(literal *ast.StringLiteral) bool {
-	return literal.Token.Flags == `"` && evaluator.ContainsShellTemplate(literal.Value)
+	return literal.Token.Flags == `"` && evaluator.ContainsShellExpansion(literal.Value)
 }
 
 func staticStringLiteral(expr ast.Expression) (*ast.StringLiteral, bool) {

--- a/typecheck.go
+++ b/typecheck.go
@@ -1,0 +1,358 @@
+package conditional
+
+import (
+	"fmt"
+
+	"github.com/buildkite/conditional/ast"
+)
+
+type valueKind string
+
+const (
+	kindUnknown     valueKind = "unknown"
+	kindString      valueKind = "string"
+	kindNumber      valueKind = "number"
+	kindBool        valueKind = "boolean"
+	kindNull        valueKind = "null"
+	kindRegexp      valueKind = "regular expression"
+	kindStringArray valueKind = "string array"
+)
+
+type enumType struct {
+	name   string
+	values map[string]struct{}
+}
+
+type valueType struct {
+	kind valueKind
+	enum *enumType
+}
+
+type functionSignature struct {
+	args []valueKind
+	ret  valueType
+}
+
+type typeChecker struct {
+	variables map[string]valueType
+	functions map[string]functionSignature
+}
+
+func typeCheckExpression(expr ast.Expression, ctx Context) error {
+	checker := typeChecker{
+		variables: variableTypes(ctx.EntryPoint),
+		functions: functionTypes(),
+	}
+
+	got, err := checker.check(expr)
+	if err != nil {
+		return err
+	}
+	if got.kind != kindBool && got.kind != kindUnknown {
+		return &Error{
+			Kind:    ErrorKindResult,
+			Message: fmt.Sprintf("expected boolean result, got %s", got.describe()),
+		}
+	}
+	return nil
+}
+
+func (c typeChecker) check(expr ast.Expression) (valueType, error) {
+	switch expr := expr.(type) {
+	case *ast.Boolean:
+		return valueType{kind: kindBool}, nil
+	case *ast.Null:
+		return valueType{kind: kindNull}, nil
+	case *ast.IntegerLiteral:
+		return valueType{kind: kindNumber}, nil
+	case *ast.StringLiteral:
+		return valueType{kind: kindString}, nil
+	case *ast.ShellExpansion:
+		return valueType{kind: kindString}, nil
+	case *ast.Regexp:
+		return valueType{kind: kindRegexp}, nil
+	case *ast.Identifier:
+		typ, ok := c.variables[expr.Value]
+		if !ok {
+			return valueType{kind: kindUnknown}, validationError("`%s` is not a variable", expr.Value)
+		}
+		return typ, nil
+	case *ast.PrefixExpression:
+		if expr.Operator != "!" {
+			return valueType{kind: kindUnknown}, validationError("`%s` is not a prefix operator", expr.Operator)
+		}
+		if err := c.expect(expr.Right, kindBool); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		return valueType{kind: kindBool}, nil
+	case *ast.InfixExpression:
+		return c.checkInfix(expr)
+	case *ast.ConditionalExpression:
+		return c.checkConditional(expr)
+	case *ast.CallExpression:
+		return c.checkCall(expr)
+	case *ast.ArrayLiteral:
+		for _, element := range expr.Elements {
+			if err := c.expect(element, kindString); err != nil {
+				return valueType{kind: kindUnknown}, err
+			}
+		}
+		return valueType{kind: kindStringArray}, nil
+	default:
+		return valueType{kind: kindUnknown}, validationError("unsupported expression type %T", expr)
+	}
+}
+
+func (c typeChecker) checkInfix(expr *ast.InfixExpression) (valueType, error) {
+	switch expr.Operator {
+	case "=~", "!~":
+		if err := c.expectAny(expr.Left, kindString, kindNull); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		if err := c.expect(expr.Right, kindRegexp); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		return valueType{kind: kindBool}, nil
+	case "includes":
+		if err := c.expectAny(expr.Left, kindStringArray, kindNull); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		if err := c.expectAny(expr.Right, kindString, kindRegexp, kindNull); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		return valueType{kind: kindBool}, nil
+	case "&&", "||":
+		if err := c.expect(expr.Left, kindBool); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		if err := c.expect(expr.Right, kindBool); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		return valueType{kind: kindBool}, nil
+	case "==", "!=":
+		if err := c.checkComparisonTypes(expr.Left, expr.Right); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+		return valueType{kind: kindBool}, nil
+	default:
+		return valueType{kind: kindUnknown}, validationError("`%s` is not a comparison operator", expr.Operator)
+	}
+}
+
+func (c typeChecker) checkConditional(expr *ast.ConditionalExpression) (valueType, error) {
+	if err := c.expect(expr.Condition, kindBool); err != nil {
+		return valueType{kind: kindUnknown}, err
+	}
+	if err := c.checkComparisonTypes(expr.Consequence, expr.Alternative); err != nil {
+		return valueType{kind: kindUnknown}, err
+	}
+	return c.check(expr.Consequence)
+}
+
+func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
+	signature, ok := c.functions[expr.Function]
+	if !ok {
+		return valueType{kind: kindUnknown}, validationError("`%s` is not a function", expr.Function)
+	}
+	if len(expr.Arguments) != len(signature.args) {
+		return valueType{kind: kindUnknown}, validationError(
+			"wrong number of arguments for `%s`: got %d, want %d",
+			expr.Function,
+			len(expr.Arguments),
+			len(signature.args),
+		)
+	}
+	for i, arg := range expr.Arguments {
+		if err := c.expect(arg, signature.args[i]); err != nil {
+			return valueType{kind: kindUnknown}, err
+		}
+	}
+	return signature.ret, nil
+}
+
+func (c typeChecker) checkComparisonTypes(left, right ast.Expression) error {
+	leftType, err := c.check(left)
+	if err != nil {
+		return err
+	}
+
+	if leftType.kind == kindNull || leftType.kind == kindUnknown {
+		_, err := c.check(right)
+		return err
+	}
+
+	if leftType.enum != nil {
+		if err := c.expectAny(right, kindString, kindNull); err != nil {
+			return err
+		}
+		if literal, ok := right.(*ast.StringLiteral); ok && !leftType.enum.includes(literal.Value) {
+			return validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
+		}
+		return nil
+	}
+
+	return c.expectAny(right, leftType.kind, kindNull)
+}
+
+func (c typeChecker) expect(expr ast.Expression, expected valueKind) error {
+	return c.expectAny(expr, expected)
+}
+
+func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error {
+	actual, err := c.check(expr)
+	if err != nil {
+		return err
+	}
+	if actual.kind == kindUnknown {
+		return nil
+	}
+	for _, expectedKind := range expected {
+		if actual.enum == nil && actual.kind == expectedKind {
+			return nil
+		}
+	}
+
+	return validationError("unexpected type: expected %s but found %s", describeKinds(expected), actual.describe())
+}
+
+func variableTypes(entryPoint EntryPoint) map[string]valueType {
+	variables := map[string]valueType{
+		"build.id":                            stringType(),
+		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "canceling", "canceled", "skipped", "not_run"),
+		"build.fixed":                         boolType(),
+		"build.blocked_state":                 enumValueType("build blocked state", "failed", "passed", "running"),
+		"build.source":                        enumValueType("build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),
+		"build.source_event":                  stringType(),
+		"build.source_action":                 stringType(),
+		"build.branch":                        stringType(),
+		"build.tag":                           stringType(),
+		"build.message":                       stringType(),
+		"build.commit":                        stringType(),
+		"build.number":                        numberType(),
+		"build.creator.id":                    stringType(),
+		"build.creator.name":                  stringType(),
+		"build.creator.email":                 stringType(),
+		"build.creator.teams":                 stringArrayType(),
+		"build.creator.verified":              boolType(),
+		"build.author.id":                     stringType(),
+		"build.author.name":                   stringType(),
+		"build.author.email":                  stringType(),
+		"build.author.teams":                  stringArrayType(),
+		"build.scm.author.name":               stringType(),
+		"build.scm.author.email":              stringType(),
+		"build.scm.committer.name":            stringType(),
+		"build.scm.committer.email":           stringType(),
+		"build.pull_request.id":               stringType(),
+		"build.pull_request.base_branch":      stringType(),
+		"build.pull_request.draft":            boolType(),
+		"build.pull_request.label":            stringType(),
+		"build.pull_request.labels":           stringArrayType(),
+		"build.pull_request.repository":       stringType(),
+		"build.pull_request.repository.fork":  boolType(),
+		"build.merge_queue.base_branch":       stringType(),
+		"build.merge_queue.base_commit":       stringType(),
+		"pipeline.id":                         stringType(),
+		"pipeline.name":                       stringType(),
+		"pipeline.slug":                       stringType(),
+		"pipeline.default_branch":             stringType(),
+		"pipeline.repository":                 stringType(),
+		"pipeline.started_passing":            boolType(),
+		"pipeline.started_failing":            boolType(),
+		"pipeline.next_finished_build_exists": boolType(),
+		"organization.id":                     stringType(),
+		"organization.slug":                   stringType(),
+	}
+
+	if stepAllowed(entryPoint) {
+		variables["step.id"] = stringType()
+		variables["step.key"] = stringType()
+		variables["step.type"] = enumValueType("step type", "command", "wait", "input", "trigger", "group")
+		variables["step.label"] = stringType()
+		variables["step.state"] = enumValueType("step state", "ignored", "waiting_for_dependencies", "ready", "running", "failing", "finished")
+		variables["step.outcome"] = enumValueType("step outcome", "neutral", "passed", "soft_failed", "hard_failed", "errored")
+	}
+
+	return variables
+}
+
+func functionTypes() map[string]functionSignature {
+	return map[string]functionSignature{
+		"env": {
+			args: []valueKind{kindString},
+			ret:  stringType(),
+		},
+		"build.env": {
+			args: []valueKind{kindString},
+			ret:  stringType(),
+		},
+	}
+}
+
+func stringType() valueType {
+	return valueType{kind: kindString}
+}
+
+func numberType() valueType {
+	return valueType{kind: kindNumber}
+}
+
+func boolType() valueType {
+	return valueType{kind: kindBool}
+}
+
+func stringArrayType() valueType {
+	return valueType{kind: kindStringArray}
+}
+
+func enumValueType(name string, values ...string) valueType {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return valueType{
+		kind: kindString,
+		enum: &enumType{name: name, values: set},
+	}
+}
+
+func (t valueType) describe() string {
+	if t.enum != nil {
+		return t.enum.name + " enumeration value"
+	}
+	return string(t.kind)
+}
+
+func (e enumType) includes(value string) bool {
+	_, ok := e.values[value]
+	return ok
+}
+
+func validationError(format string, args ...any) *Error {
+	return &Error{Kind: ErrorKindValidation, Message: fmt.Sprintf(format, args...)}
+}
+
+func describeKinds(kinds []valueKind) string {
+	if len(kinds) == 1 {
+		return string(kinds[0])
+	}
+
+	out := ""
+	for i, kind := range kinds {
+		switch {
+		case i == 0:
+			out = string(kind)
+		case i == len(kinds)-1:
+			out += " or " + string(kind)
+		default:
+			out += ", " + string(kind)
+		}
+	}
+	return out
+}
+
+func identifierName(expr ast.Expression) string {
+	if ident, ok := expr.(*ast.Identifier); ok {
+		return ident.Value
+	}
+	return expr.String()
+}

--- a/typecheck.go
+++ b/typecheck.go
@@ -82,7 +82,7 @@ func (c typeChecker) check(expr ast.Expression) (valueType, error) {
 		if expr.Operator != "!" {
 			return valueType{kind: kindUnknown}, validationError("`%s` is not a prefix operator", expr.Operator)
 		}
-		if err := c.expect(expr.Right, kindBool); err != nil {
+		if err := c.expectAny(expr.Right, kindBool, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -174,14 +174,22 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 		return valueType{kind: kindUnknown}, err
 	}
 
-	if leftType.kind == kindNull || leftType.kind == kindUnknown {
-		rightType, err := c.check(right)
-		return rightType.withNull(), err
+	rightType, err := c.check(right)
+	if err != nil {
+		return valueType{kind: kindUnknown}, err
 	}
 	if leftType.kind == kindStringArray {
 		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", leftType.describe())
 	}
-
+	if rightType.kind == kindStringArray {
+		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", rightType.describe())
+	}
+	if leftType.kind == kindNull || leftType.kind == kindUnknown {
+		return rightType.withNull(), nil
+	}
+	if rightType.kind == kindNull || rightType.kind == kindUnknown {
+		return leftType.withNull(), nil
+	}
 	if leftType.enum != nil {
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
@@ -189,27 +197,20 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 		if literal, ok := right.(*ast.StringLiteral); ok && !leftType.enum.includes(literal.Value) {
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
 		}
-		return leftType, nil
+		return leftType.withNullabilityFrom(rightType), nil
 	}
 
-	rightType, err := c.check(right)
-	if err != nil {
-		return valueType{kind: kindUnknown}, err
-	}
 	if rightType.enum != nil && leftType.kind == kindString {
 		if literal, ok := left.(*ast.StringLiteral); ok && !rightType.enum.includes(literal.Value) {
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(right))
 		}
-		return rightType, nil
-	}
-	if rightType.kind == kindStringArray {
-		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", rightType.describe())
+		return rightType.withNullabilityFrom(leftType), nil
 	}
 
 	if err := c.expectAny(right, leftType.kind, kindNull); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	return leftType, nil
+	return leftType.withNullabilityFrom(rightType), nil
 }
 
 func (c typeChecker) expect(expr ast.Expression, expected valueKind) error {
@@ -381,6 +382,13 @@ func (t valueType) withNull() valueType {
 		return t
 	}
 	t.nullable = true
+	return t
+}
+
+func (t valueType) withNullabilityFrom(other valueType) valueType {
+	if other.kind == kindNull || other.nullable {
+		return t.withNull()
+	}
 	return t
 }
 

--- a/typecheck.go
+++ b/typecheck.go
@@ -70,7 +70,7 @@ func (c typeChecker) check(expr ast.Expression) (valueType, error) {
 	case *ast.StringLiteral:
 		return valueType{kind: kindString}, nil
 	case *ast.ShellExpansion:
-		return valueType{kind: kindString}, nil
+		return nullableStringType(), nil
 	case *ast.Regexp:
 		return valueType{kind: kindRegexp}, nil
 	case *ast.Identifier:
@@ -322,59 +322,59 @@ func (c typeChecker) expectIncludesRight(expr ast.Expression) error {
 
 func variableTypes(ctx Context) map[string]valueType {
 	variables := map[string]valueType{
-		"build.id":                            stringType(),
-		"build.state":                         enumValueType("build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
+		"build.id":                            stringTypeFor(ctx.Build.ID),
+		"build.state":                         enumValueTypeFor(ctx.Build.State, "build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
 		"build.fixed":                         boolTypeFor(ctx.Build.Fixed),
-		"build.blocked_state":                 enumValueType("build blocked state", "failed", "passed", "running"),
-		"build.source":                        enumValueType("build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),
-		"build.source_event":                  stringType(),
-		"build.source_action":                 stringType(),
-		"build.branch":                        stringType(),
-		"build.tag":                           stringType(),
-		"build.message":                       stringType(),
-		"build.commit":                        stringType(),
+		"build.blocked_state":                 enumValueTypeFor(ctx.Build.BlockedState, "build blocked state", "failed", "passed", "running"),
+		"build.source":                        enumValueTypeFor(ctx.Build.Source, "build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),
+		"build.source_event":                  stringTypeFor(sourceEvent(ctx)),
+		"build.source_action":                 stringTypeFor(sourceAction(ctx)),
+		"build.branch":                        stringTypeFor(ctx.Build.Branch),
+		"build.tag":                           stringTypeFor(ctx.Build.Tag),
+		"build.message":                       stringTypeFor(ctx.Build.Message),
+		"build.commit":                        stringTypeFor(ctx.Build.Commit),
 		"build.number":                        numberType(),
-		"build.creator.id":                    stringType(),
-		"build.creator.name":                  stringType(),
-		"build.creator.email":                 stringType(),
-		"build.creator.teams":                 stringArrayType(),
+		"build.creator.id":                    stringTypeFor(ctx.Build.Creator.ID),
+		"build.creator.name":                  stringTypeFor(ctx.Build.Creator.Name),
+		"build.creator.email":                 stringTypeFor(ctx.Build.Creator.Email),
+		"build.creator.teams":                 stringArrayTypeFor(ctx.Build.Creator.Teams),
 		"build.creator.verified":              boolTypeFor(ctx.Build.Creator.Verified),
-		"build.author.id":                     stringType(),
-		"build.author.name":                   stringType(),
-		"build.author.email":                  stringType(),
-		"build.author.teams":                  stringArrayType(),
-		"build.scm.author.name":               stringType(),
-		"build.scm.author.email":              stringType(),
-		"build.scm.committer.name":            stringType(),
-		"build.scm.committer.email":           stringType(),
-		"build.pull_request.id":               stringType(),
-		"build.pull_request.base_branch":      stringType(),
+		"build.author.id":                     stringTypeFor(ctx.Build.Author.ID),
+		"build.author.name":                   stringTypeFor(ctx.Build.Author.Name),
+		"build.author.email":                  stringTypeFor(ctx.Build.Author.Email),
+		"build.author.teams":                  stringArrayTypeFor(ctx.Build.Author.Teams),
+		"build.scm.author.name":               stringTypeFor(ctx.Build.SCM.AuthorName),
+		"build.scm.author.email":              stringTypeFor(ctx.Build.SCM.AuthorEmail),
+		"build.scm.committer.name":            stringTypeFor(ctx.Build.SCM.CommitterName),
+		"build.scm.committer.email":           stringTypeFor(ctx.Build.SCM.CommitterEmail),
+		"build.pull_request.id":               stringTypeFor(ctx.Build.PullRequest.ID),
+		"build.pull_request.base_branch":      stringTypeFor(ctx.Build.PullRequest.BaseBranch),
 		"build.pull_request.draft":            boolTypeFor(ctx.Build.PullRequest.Draft),
-		"build.pull_request.label":            stringType(),
-		"build.pull_request.labels":           stringArrayType(),
-		"build.pull_request.repository":       stringType(),
+		"build.pull_request.label":            stringTypeFor(pullRequestLabel(ctx)),
+		"build.pull_request.labels":           stringArrayTypeFor(ctx.Build.PullRequest.Labels),
+		"build.pull_request.repository":       stringTypeFor(ctx.Build.PullRequest.Repository),
 		"build.pull_request.repository.fork":  boolTypeFor(ctx.Build.PullRequest.RepositoryFork),
-		"build.merge_queue.base_branch":       stringType(),
-		"build.merge_queue.base_commit":       stringType(),
-		"pipeline.id":                         stringType(),
-		"pipeline.name":                       stringType(),
-		"pipeline.slug":                       stringType(),
-		"pipeline.default_branch":             stringType(),
-		"pipeline.repository":                 stringType(),
+		"build.merge_queue.base_branch":       stringTypeFor(ctx.Build.MergeQueue.BaseBranch),
+		"build.merge_queue.base_commit":       stringTypeFor(ctx.Build.MergeQueue.BaseCommit),
+		"pipeline.id":                         stringTypeFor(ctx.Pipeline.ID),
+		"pipeline.name":                       stringTypeFor(ctx.Pipeline.Name),
+		"pipeline.slug":                       stringTypeFor(ctx.Pipeline.Slug),
+		"pipeline.default_branch":             stringTypeFor(ctx.Pipeline.DefaultBranch),
+		"pipeline.repository":                 stringTypeFor(ctx.Pipeline.Repository),
 		"pipeline.started_passing":            boolTypeFor(ctx.Pipeline.StartedPassing),
 		"pipeline.started_failing":            boolTypeFor(ctx.Pipeline.StartedFailing),
 		"pipeline.next_finished_build_exists": boolTypeFor(ctx.Pipeline.NextFinishedBuildExists),
-		"organization.id":                     stringType(),
-		"organization.slug":                   stringType(),
+		"organization.id":                     stringTypeFor(ctx.Organization.ID),
+		"organization.slug":                   stringTypeFor(ctx.Organization.Slug),
 	}
 
 	if stepAllowed(ctx.EntryPoint) {
-		variables["step.id"] = stringType()
-		variables["step.key"] = stringType()
-		variables["step.type"] = enumValueType("step type", "command", "wait", "input", "trigger", "group")
-		variables["step.label"] = stringType()
-		variables["step.state"] = enumValueType("step state", "ignored", "waiting_for_dependencies", "ready", "running", "failing", "finished")
-		variables["step.outcome"] = enumValueType("step outcome", "neutral", "passed", "soft_failed", "hard_failed", "errored")
+		variables["step.id"] = stringTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.ID }))
+		variables["step.key"] = stringTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Key }))
+		variables["step.type"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Type }), "step type", "command", "wait", "input", "trigger", "group")
+		variables["step.label"] = stringTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Label }))
+		variables["step.state"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.State }), "step state", "ignored", "waiting_for_dependencies", "ready", "running", "failing", "finished")
+		variables["step.outcome"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Outcome }), "step outcome", "neutral", "passed", "soft_failed", "hard_failed", "errored")
 	}
 
 	return variables
@@ -388,13 +388,24 @@ func functionTypes() map[string]functionSignature {
 		},
 		"build.env": {
 			args: []valueKind{kindString},
-			ret:  stringType(),
+			ret:  nullableStringType(),
 		},
 	}
 }
 
 func stringType() valueType {
 	return valueType{kind: kindString}
+}
+
+func nullableStringType() valueType {
+	return valueType{kind: kindString, nullable: true}
+}
+
+func stringTypeFor(value *string) valueType {
+	if value == nil {
+		return nullableStringType()
+	}
+	return stringType()
 }
 
 func numberType() valueType {
@@ -420,6 +431,17 @@ func stringArrayType() valueType {
 	return valueType{kind: kindStringArray}
 }
 
+func nullableStringArrayType() valueType {
+	return valueType{kind: kindStringArray, nullable: true}
+}
+
+func stringArrayTypeFor(values []string) valueType {
+	if values == nil {
+		return nullableStringArrayType()
+	}
+	return stringArrayType()
+}
+
 func enumValueType(name string, values ...string) valueType {
 	set := make(map[string]struct{}, len(values))
 	for _, value := range values {
@@ -429,6 +451,21 @@ func enumValueType(name string, values ...string) valueType {
 		kind: kindString,
 		enum: &enumType{name: name, values: set},
 	}
+}
+
+func enumValueTypeFor(value *string, name string, values ...string) valueType {
+	typ := enumValueType(name, values...)
+	if value == nil {
+		typ.nullable = true
+	}
+	return typ
+}
+
+func stepString(step *Step, value func(*Step) *string) *string {
+	if step == nil {
+		return nil
+	}
+	return value(step)
 }
 
 func (t valueType) describe() string {

--- a/typecheck.go
+++ b/typecheck.go
@@ -95,7 +95,7 @@ func (c typeChecker) check(expr ast.Expression) (valueType, error) {
 		return c.checkCall(expr)
 	case *ast.ArrayLiteral:
 		for _, element := range expr.Elements {
-			if err := c.expect(element, kindString); err != nil {
+			if err := c.expectArrayElement(element); err != nil {
 				return valueType{kind: kindUnknown}, err
 			}
 		}
@@ -152,7 +152,16 @@ func (c typeChecker) checkConditional(expr *ast.ConditionalExpression) (valueTyp
 	if err := c.expect(expr.Condition, kindBool); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	return c.checkCompatibleTypes(expr.Consequence, expr.Alternative, true)
+	consequenceChecker := c
+	alternativeChecker := c
+	if name, consequenceIsNonNull, ok := nonNullGuardForConditional(expr.Condition); ok {
+		if consequenceIsNonNull {
+			consequenceChecker = c.withNonNullableVariable(name)
+		} else {
+			alternativeChecker = c.withNonNullableVariable(name)
+		}
+	}
+	return consequenceChecker.checkCompatibleTypesWith(alternativeChecker, expr.Consequence, expr.Alternative, true)
 }
 
 func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
@@ -181,12 +190,16 @@ func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType
 }
 
 func (c typeChecker) checkCompatibleTypes(left, right ast.Expression, allowArrays bool) (valueType, error) {
+	return c.checkCompatibleTypesWith(c, left, right, allowArrays)
+}
+
+func (c typeChecker) checkCompatibleTypesWith(rightChecker typeChecker, left, right ast.Expression, allowArrays bool) (valueType, error) {
 	leftType, err := c.check(left)
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
 
-	rightType, err := c.check(right)
+	rightType, err := rightChecker.check(right)
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
@@ -276,6 +289,20 @@ func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error
 	}
 
 	return validationError("unexpected type: expected %s but found %s", describeKinds(expected), actual.describe())
+}
+
+func (c typeChecker) expectArrayElement(expr ast.Expression) error {
+	actual, err := c.check(expr)
+	if err != nil {
+		return err
+	}
+	if actual.kind == kindUnknown {
+		return nil
+	}
+	if actual.kind == kindString && !actual.nullable {
+		return nil
+	}
+	return validationError("unexpected type: expected string but found %s", actual.describe())
 }
 
 func (c typeChecker) expectIncludesRight(expr ast.Expression) error {
@@ -506,6 +533,25 @@ func nonNullGuardForRHS(operator string, left ast.Expression) (string, bool) {
 		return nullComparedIdentifier(guard.Left, guard.Right)
 	default:
 		return "", false
+	}
+}
+
+func nonNullGuardForConditional(condition ast.Expression) (name string, consequenceIsNonNull bool, ok bool) {
+	guard, ok := condition.(*ast.InfixExpression)
+	if !ok {
+		return "", false, false
+	}
+	name, ok = nullComparedIdentifier(guard.Left, guard.Right)
+	if !ok {
+		return "", false, false
+	}
+	switch guard.Operator {
+	case "!=":
+		return name, true, true
+	case "==":
+		return name, false, true
+	default:
+		return "", false, false
 	}
 }
 


### PR DESCRIPTION
Buildkite evaluates conditionals through a parser/type-checker/evaluator pipeline, but the Go root API was still relying on runtime evaluation for many server-invalid expressions. That let unknown variables, incompatible operand types, invalid function calls, and shell substitutions behave like generic expression-language cases instead of Buildkite conditionals.

This adds a root-level type checker for the modeled Buildkite variables and functions, validates enum literals and env() arguments before runtime, and evaluates the upstream shell-substitution matrix against the merged Buildkite environment. It also aligns evaluator behavior for null =~ /.../, null includes ..., and regex RHS includes.

Examples covered by the new conformance tables include `${notset} == null`, `${empty:-xx} == "xx"`, `${branch:${empty:-1}:${two+2}} == "ai"`, `"${branch}" == "main"`, `build.creator.teams includes /dep/`, and `build.state == "faillled"` failing validation.