### PR TITLE
fix: Align declared type semantics

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -61,6 +61,8 @@ func evaluate(expression string, ctx Context) (bool, error) {
 	switch result := result.(type) {
 	case *object.Boolean:
 		return result.Value, nil
+	case *object.Null:
+		return false, nil
 	case *object.Error:
 		return false, &Error{Kind: ErrorKindEvaluation, Message: result.Message}
 	default:
@@ -118,9 +120,6 @@ func validateEnvCalls(expr ast.Expression) error {
 	case *ast.InfixExpression:
 		if err := validateEnvCalls(expr.Left); err != nil {
 			return err
-		}
-		if logicalExpressionShortCircuits(expr) {
-			return nil
 		}
 		return validateEnvCalls(expr.Right)
 	case *ast.CallExpression:
@@ -185,9 +184,6 @@ func validateOperators(expr ast.Expression) error {
 		}
 		if err := validateOperators(expr.Left); err != nil {
 			return err
-		}
-		if logicalExpressionShortCircuits(expr) {
-			return nil
 		}
 		return validateOperators(expr.Right)
 	case *ast.CallExpression:

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -344,8 +344,8 @@ Initial manifest:
 | Upstream source | Groups to account for | Current status | Required status before parity claim |
 | --- | --- | --- | --- |
 | `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; Slice 4 starts double-quoted shell interpolation. Exact friendly messages, token positions, and full string escape parity remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 4 ports regex includes, null regex/includes semantics, shell substitution evaluation, double-quoted interpolation, enum literal validation, and type-checker rejection for representative mismatches. Full custom function/lazy variable coverage remains | `ported` |
-| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: Slice 4 adds root-level typed variable and enum validation for the Buildkite context model; lazy variable internals and exhaustive variable specs remain Slice 5/cleanup work | `ported` or `superseded` by Go type/context tests |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 4 ports regex includes, null regex/includes semantics, shell substitution evaluation, double-quoted interpolation, enum literal validation, logical type-checking before runtime short-circuiting, enum comparison asymmetry, array equality/null comparisons, Ruby-style falsey runtime behavior for typed nil booleans, and representative type-checker rejection cases. Full custom function/lazy variable coverage remains | `ported` |
+| `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: Slice 4 ports the server's declared-type behavior for nil values: typed nil strings, booleans, arrays, and enums type-check as their declared type rather than nullable unions. Lazy variable internals and exhaustive variable specs remain Slice 5/cleanup work | `ported` or `superseded` by Go type/context tests |
 | `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Slice 2 seeds source-tagged root cases for representative `env()`, `build.env()`, organization, pipeline, webhook, pull request label, project env merge, and validation behavior; the exhaustive context matrix is Slice 5 | `ported` |
 | `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: Slice 2 ports blank string, invalid expression, step-variable rejection, and step-option acceptance through root validation; nil validation is not representable in the string API | `ported` or `intentionally_excluded` with reason |
 | `spec/models/build/notification_spec.rb` | no conditional, false on unmet condition, false on parser/evaluation errors | `blocked`: Slice 2 ports blank/no-condition equivalent, false-on-unmet condition, false-on-parse-error, and false-on-unavailable-step-variable behavior; full notification parsing/config propagation remains out of scope | `ported` |
@@ -387,8 +387,15 @@ from this plan.
 - Slice 3 landed parser grammar alignment for flat dotted identifiers/functions,
   ternary parsing, shell expansion operands, parser-level `@>` rejection, and
   unterminated string/substitution errors.
+- Slice 4 now aligns the root type checker with server declared-type semantics:
+  Buildkite assignments keep their declared type even when the runtime value is
+  nil, enums are not interchangeable with strings except for server-supported
+  enum-to-static-string comparisons, logical operands are type-checked on both
+  sides before runtime short-circuiting, and ternary branches do not create
+  flow-sensitive nullable unions.
 - Some landed behavior is still explicitly provisional because it diverges from
-  the server regex validator or still lacks the server type checker.
+  the server regex validator or still lacks exhaustive custom function/lazy
+  variable coverage.
 
 ### Active Slice
 
@@ -401,6 +408,12 @@ from this plan.
 - Evaluator semantics now match upstream cases for regex `includes`, `null
   includes ...`, `null =~ /.../`, `null !~ /.../`, and short-circuiting branches
   that would otherwise fail at runtime.
+- Runtime evaluation now uses the server's Ruby truthiness for logical and
+  ternary decisions, so typed nil booleans are falsey and `!nil` is true through
+  the root API.
+- Equality semantics now allow array-vs-array and array-vs-null comparisons,
+  while `includes` rejects enum values as enum token types rather than treating
+  them as plain strings.
 - Shell expansion operands now evaluate against the merged Buildkite
   environment for set, unset, empty, required, default, alternate, substring,
   nested substring argument, and bad substring length cases.
@@ -418,16 +431,16 @@ from this plan.
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
 | Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables. Some public implementation packages still expose older generic-language concepts during transition. | Finish removing nested object lookup assumptions and move implementation packages under `internal/` in the cleanup slice. |
-| `build.env()` | `build.env("NAME")` parses as a flat function identifier and evaluates through the root adapter. | Expand validator and conformance coverage for server-compatible nullable return behavior in Slice 5. |
-| Ternary syntax | Ternaries parse with server precedence, evaluate lazily, and now type-check branch compatibility through the root API. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
+| `build.env()` | `build.env("NAME")` parses as a flat function identifier, type-checks with the server's string return token type, and evaluates to `null` for absent variables through the root adapter. | Expand validator and conformance coverage for the full server env matrix in Slice 5. |
+| Ternary syntax | Ternaries parse with server precedence, evaluate lazily, use Ruby truthiness for nil runtime conditions, and type-check branch compatibility without local nullable-union narrowing. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
 | Shell substitution | Shell expansion operands and double-quoted interpolation evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix. | Finish exact string escape parity, shell fallback string grammar coverage, and package-local parser/evaluator tests for edge cases beyond the current root tables. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |
-| Nullable values | Missing nested properties error. | Documented nullable variables should be present as `null` for the right contexts. Truly unknown properties should still fail closed. |
+| Nullable values | Documented nullable Buildkite assignments are present as runtime `null` while keeping their server-declared type for validation. Truly unknown variables still fail closed. | Finish the exhaustive context matrix and lazy variable coverage so every documented nullable field is covered in every entrypoint. |
 | Context restrictions | No context kind. | Enforce pipeline, step, build-notification, and step-notification variable availability. |
 | Final result | Root `Validate`/`Evaluate` now type-check for a boolean final result; lower-level `Eval` still returns any `object.Object` during transition. | Move implementation packages under `internal/` and keep root `(bool, error)` as the supported Buildkite surface. |
 | Regex syntax | regexp2 accepts some features the server rejects. | Keep regexp2 only with a server-compatible validator for flags and unsupported constructs. |
 | Divergent operators | `@>` no longer tokenizes as a Buildkite parser operator. Some lower-level compatibility constants may remain until cleanup. | Remove remaining dead `@>` constants or generic-language artifacts in the cleanup slice. |
-| Type mismatch semantics | Local behavior exists but is not server-proven. | Build a server-derived matrix for equality, regex matching, `includes`, `!`, missing values, and function argument errors. |
+| Type mismatch semantics | Core equality, regex matching, `includes`, `!`, logical, ternary, enum, null, and array comparison cases now use server-derived type-checking behavior. | Finish the remaining server-derived matrix for custom functions, lazy variables, function argument validators, and exact error categories. |
 | Conformance | Root package tests are now split into source-tagged table-driven files for syntax, evaluation, regex, context, and root API error behavior. The tables seed docs and upstream spec coverage but do not yet port every blocked upstream group. | Expand the tables in each implementation slice until every manifest group is `ported`, `superseded`, or `intentionally_excluded` before claiming parity. |
 
 ## Server Syntax And Context Surface To Cover

--- a/eval_test.go
+++ b/eval_test.go
@@ -73,6 +73,30 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "array equality evaluates matching arrays",
+			source:     upstreamParserSpec,
+			expression: `["a"] == ["a"]`,
+			want:       true,
+		},
+		{
+			name:       "array null equality evaluates false",
+			source:     upstreamParserSpec,
+			expression: `["a"] == null`,
+			want:       false,
+		},
+		{
+			name:       "null array equality evaluates false",
+			source:     upstreamParserSpec,
+			expression: `null == ["a"]`,
+			want:       false,
+		},
+		{
+			name:       "nil array variable compares equal to null",
+			source:     upstreamConditionalVariableSpec,
+			expression: `null == build.creator.teams`,
+			want:       true,
+		},
+		{
 			name:       "array includes regex",
 			source:     upstreamEvaluatorSpec,
 			expression: `build.creator.teams includes /dep/`,
@@ -84,22 +108,22 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
-			name:       "array includes enum string variable",
-			source:     docsConditionalsSource,
+			name:       "array includes rejects enum variable",
+			source:     upstreamParserSpec,
 			expression: `["passed", "failed"] includes build.state`,
 			ctx: Context{
 				Build: Build{State: str("passed")},
 			},
-			want: true,
+			wantError: ErrorKindValidation,
 		},
 		{
-			name:       "array literal accepts enum string variable",
-			source:     upstreamEvaluatorSpec,
+			name:       "array literal rejects enum variable element",
+			source:     upstreamParserSpec,
 			expression: `[build.state] includes "passed"`,
 			ctx: Context{
 				Build: Build{State: str("passed")},
 			},
-			want: true,
+			wantError: ErrorKindValidation,
 		},
 		{
 			name:       "documented started failing build state",
@@ -130,22 +154,22 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want: true,
 		},
 		{
-			name:       "enum comparison allows same enum variables",
+			name:       "enum comparison rejects same enum variables",
 			source:     upstreamParserSpec,
 			expression: `build.state == build.state`,
 			ctx: Context{
 				Build: Build{State: str("passed")},
 			},
-			want: true,
+			wantError: ErrorKindValidation,
 		},
 		{
-			name:       "valid enum comparison can put literal first",
+			name:       "enum comparison rejects literal first",
 			source:     upstreamParserSpec,
 			expression: `"passed" == build.state`,
 			ctx: Context{
 				Build: Build{State: str("passed")},
 			},
-			want: true,
+			wantError: ErrorKindValidation,
 		},
 		{
 			name:       "null includes string evaluates false",
@@ -178,16 +202,16 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       true,
 		},
 		{
-			name:       "logical and short-circuits missing variable validation",
+			name:       "logical and still type checks missing variable",
 			source:     upstreamEvaluatorSpec,
 			expression: `false && missing.value == "x"`,
-			want:       false,
+			wantError:  ErrorKindValidation,
 		},
 		{
-			name:       "logical or short-circuits missing variable validation",
+			name:       "logical or still type checks missing variable",
 			source:     upstreamEvaluatorSpec,
 			expression: `true || missing.value == "x"`,
-			want:       true,
+			wantError:  ErrorKindValidation,
 		},
 		{
 			name:       "nested precedence with and before or",
@@ -239,40 +263,40 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			wantError:  ErrorKindResult,
 		},
 		{
-			name:       "nullable pointer backed boolean result fails closed",
-			source:     upstreamBuildValidatorSpec,
+			name:       "typed nil boolean result is falsey",
+			source:     upstreamConditionalVariableSpec,
 			expression: `build.fixed`,
-			wantError:  ErrorKindResult,
+			want:       false,
 		},
 		{
-			name:       "nullable context string fails inside array literal",
-			source:     upstreamBuildValidatorSpec,
+			name:       "typed nil string in array literal fails during evaluation",
+			source:     upstreamConditionalVariableSpec,
 			expression: `[build.tag] includes "v1.0"`,
-			wantError:  ErrorKindValidation,
+			wantError:  ErrorKindEvaluation,
 		},
 		{
-			name:       "nullable build env fails inside array literal",
-			source:     upstreamBuildValidatorSpec,
+			name:       "nil build env in array literal fails during evaluation",
+			source:     upstreamBuildConditionSpec,
 			expression: `[build.env("MISSING")] includes "x"`,
-			wantError:  ErrorKindValidation,
+			wantError:  ErrorKindEvaluation,
 		},
 		{
-			name:       "nullable shell expansion fails inside array literal",
-			source:     upstreamBuildValidatorSpec,
+			name:       "nil shell expansion in array literal fails during evaluation",
+			source:     upstreamEvaluatorSpec,
 			expression: `[${notset}] includes "x"`,
-			wantError:  ErrorKindValidation,
+			wantError:  ErrorKindEvaluation,
 		},
 		{
-			name:       "nullable ternary result fails closed",
+			name:       "typed nil ternary result is falsey",
 			source:     upstreamParserSpec,
 			expression: `true ? null : true`,
-			wantError:  ErrorKindResult,
+			want:       false,
 		},
 		{
-			name:       "nullable ternary alternative result fails closed",
+			name:       "typed nil ternary alternative result is falsey",
 			source:     upstreamParserSpec,
 			expression: `false ? true : null`,
-			wantError:  ErrorKindResult,
+			want:       false,
 		},
 		{
 			name:       "nullable pull request boolean can be negated",
@@ -293,14 +317,47 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "nullable pull request boolean fails before logical evaluation",
+			name:       "nullable pull request boolean is falsey in logical evaluation",
 			source:     docsConditionalsSource,
 			expression: `build.pull_request.draft || false`,
-			wantError:  ErrorKindValidation,
+			want:       false,
 		},
 	}
 
 	runEvaluateCases(t, tests)
+}
+
+func TestConditionalDeclaredTypeValidation(t *testing.T) {
+	tests := []validateCase{
+		{
+			name:       "typed nil boolean validates as boolean",
+			source:     upstreamConditionalVariableSpec,
+			expression: `build.fixed`,
+		},
+		{
+			name:       "typed nil boolean validates in logical expression",
+			source:     upstreamConditionalVariableSpec,
+			expression: `build.pull_request.draft || false`,
+		},
+		{
+			name:       "typed nil string validates against null",
+			source:     upstreamConditionalVariableSpec,
+			expression: `build.tag == null`,
+		},
+		{
+			name:       "null ternary branch validates against boolean branch",
+			source:     upstreamParserSpec,
+			expression: `true ? null : true`,
+		},
+		{
+			name:       "logical expression still validates skipped missing variable",
+			source:     upstreamParserSpec,
+			expression: `false && missing.value == "x"`,
+			wantError:  ErrorKindValidation,
+		},
+	}
+
+	runValidateCases(t, tests)
 }
 
 func TestConditionalShellSubstitutionEvaluation(t *testing.T) {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -112,12 +112,7 @@ func evalConditionalExpression(node *ast.ConditionalExpression, scope Scope) obj
 		return condition
 	}
 
-	conditionVal, ok := condition.(*object.Boolean)
-	if !ok {
-		return newError("conditional condition must be BOOLEAN, got %s", condition.Type())
-	}
-
-	if conditionVal.Value {
+	if isTruthy(condition) {
 		return Eval(node.Consequence, scope)
 	}
 	return Eval(node.Alternative, scope)
@@ -178,19 +173,14 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 }
 
 func evalLogicalExpression(operator string, left object.Object, rightExp ast.Expression, scope Scope) object.Object {
-	leftVal, ok := left.(*object.Boolean)
-	if !ok {
-		return newError("type mismatch: %s %s BOOLEAN", left.Type(), operator)
-	}
-
 	switch operator {
 	case "&&":
-		if !leftVal.Value {
-			return FALSE
+		if !isTruthy(left) {
+			return left
 		}
 	case "||":
-		if leftVal.Value {
-			return TRUE
+		if isTruthy(left) {
+			return left
 		}
 	}
 
@@ -199,12 +189,7 @@ func evalLogicalExpression(operator string, left object.Object, rightExp ast.Exp
 		return right
 	}
 
-	rightVal, ok := right.(*object.Boolean)
-	if !ok {
-		return newError("type mismatch: BOOLEAN %s %s", operator, right.Type())
-	}
-
-	return nativeBoolToBooleanObject(rightVal.Value)
+	return right
 }
 
 func evalBangOperatorExpression(right object.Object) object.Object {
@@ -217,6 +202,17 @@ func evalBangOperatorExpression(right object.Object) object.Object {
 		return TRUE
 	default:
 		return FALSE
+	}
+}
+
+func isTruthy(obj object.Object) bool {
+	switch obj := obj.(type) {
+	case *object.Boolean:
+		return obj.Value
+	case *object.Null:
+		return false
+	default:
+		return true
 	}
 }
 
@@ -331,6 +327,10 @@ func evalArrayInfixExpression(operator string, left, right object.Object) object
 	leftVal := left.(*object.Array)
 
 	switch operator {
+	case "==":
+		return nativeBoolToBooleanObject(left.Equals(right))
+	case "!=":
+		return nativeBoolToBooleanObject(!left.Equals(right))
 	case "includes":
 		contains, err := arrayContains(leftVal, right)
 		if err != nil {

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -184,30 +184,6 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindValidation,
 		},
 		{
-			name:       "validation rejects array equality",
-			source:     upstreamParserSpec,
-			expression: `["a"] == ["a"]`,
-			wantError:  ErrorKindValidation,
-		},
-		{
-			name:       "validation rejects array null equality",
-			source:     upstreamParserSpec,
-			expression: `["a"] == null`,
-			wantError:  ErrorKindValidation,
-		},
-		{
-			name:       "validation rejects null array equality",
-			source:     upstreamParserSpec,
-			expression: `null == ["a"]`,
-			wantError:  ErrorKindValidation,
-		},
-		{
-			name:       "validation rejects null array variable equality",
-			source:     upstreamParserSpec,
-			expression: `null == build.creator.teams`,
-			wantError:  ErrorKindValidation,
-		},
-		{
 			name:       "validation rejects invalid enum literal",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.state == "faillled"`,

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -5,13 +5,14 @@ import "testing"
 const (
 	docsConditionalsSource = "https://buildkite.com/docs/pipelines/configure/conditionals"
 
-	upstreamParserSpec             = "buildkite/buildkite:spec/models/conditional/parser_spec.rb"
-	upstreamEvaluatorSpec          = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
-	upstreamBuildConditionSpec     = "buildkite/buildkite:spec/models/build/condition_spec.rb"
-	upstreamBuildValidatorSpec     = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
-	upstreamBuildNotificationSpec  = "buildkite/buildkite:spec/models/build/notification_spec.rb"
-	upstreamStepNotificationSpec   = "buildkite/buildkite:spec/models/step/notification_spec.rb"
-	upstreamConditionalRegexpModel = "buildkite/buildkite:app/models/conditional/regexp.rb"
+	upstreamParserSpec              = "buildkite/buildkite:spec/models/conditional/parser_spec.rb"
+	upstreamEvaluatorSpec           = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
+	upstreamConditionalVariableSpec = "buildkite/buildkite:spec/models/conditional/variable_spec.rb"
+	upstreamBuildConditionSpec      = "buildkite/buildkite:spec/models/build/condition_spec.rb"
+	upstreamBuildValidatorSpec      = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
+	upstreamBuildNotificationSpec   = "buildkite/buildkite:spec/models/build/notification_spec.rb"
+	upstreamStepNotificationSpec    = "buildkite/buildkite:spec/models/step/notification_spec.rb"
+	upstreamConditionalRegexpModel  = "buildkite/buildkite:app/models/conditional/regexp.rb"
 )
 
 type evaluateCase struct {

--- a/typecheck.go
+++ b/typecheck.go
@@ -25,9 +25,8 @@ type enumType struct {
 }
 
 type valueType struct {
-	kind     valueKind
-	enum     *enumType
-	nullable bool
+	kind valueKind
+	enum *enumType
 }
 
 type functionSignature struct {
@@ -50,7 +49,7 @@ func typeCheckExpression(expr ast.Expression, ctx Context) error {
 	if err != nil {
 		return err
 	}
-	if (got.kind != kindBool && got.kind != kindUnknown) || got.nullable {
+	if got.kind != kindBool && got.kind != kindUnknown {
 		return &Error{
 			Kind:    ErrorKindResult,
 			Message: fmt.Sprintf("expected boolean result, got %s", got.describe()),
@@ -70,7 +69,7 @@ func (c typeChecker) check(expr ast.Expression) (valueType, error) {
 	case *ast.StringLiteral:
 		return valueType{kind: kindString}, nil
 	case *ast.ShellExpansion:
-		return nullableStringType(), nil
+		return stringType(), nil
 	case *ast.Regexp:
 		return valueType{kind: kindRegexp}, nil
 	case *ast.Identifier:
@@ -83,7 +82,7 @@ func (c typeChecker) check(expr ast.Expression) (valueType, error) {
 		if expr.Operator != "!" {
 			return valueType{kind: kindUnknown}, validationError("`%s` is not a prefix operator", expr.Operator)
 		}
-		if err := c.expectAny(expr.Right, kindBool, kindNull); err != nil {
+		if err := c.expect(expr.Right, kindBool); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -127,14 +126,7 @@ func (c typeChecker) checkInfix(expr *ast.InfixExpression) (valueType, error) {
 		if err := c.expect(expr.Left, kindBool); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
-		if logicalExpressionShortCircuits(expr) {
-			return valueType{kind: kindBool}, nil
-		}
-		rightChecker := c
-		if name, ok := nonNullGuardForRHS(expr.Operator, expr.Left); ok {
-			rightChecker = c.withNonNullableVariable(name)
-		}
-		if err := rightChecker.expect(expr.Right, kindBool); err != nil {
+		if err := c.expect(expr.Right, kindBool); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		return valueType{kind: kindBool}, nil
@@ -152,16 +144,7 @@ func (c typeChecker) checkConditional(expr *ast.ConditionalExpression) (valueTyp
 	if err := c.expect(expr.Condition, kindBool); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	consequenceChecker := c
-	alternativeChecker := c
-	if name, consequenceIsNonNull, ok := nonNullGuardForConditional(expr.Condition); ok {
-		if consequenceIsNonNull {
-			consequenceChecker = c.withNonNullableVariable(name)
-		} else {
-			alternativeChecker = c.withNonNullableVariable(name)
-		}
-	}
-	return consequenceChecker.checkCompatibleTypesWith(alternativeChecker, expr.Consequence, expr.Alternative, true)
+	return c.checkCompatibleTypes(expr.Consequence, expr.Alternative)
 }
 
 func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
@@ -186,84 +169,45 @@ func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
 }
 
 func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType, error) {
-	return c.checkCompatibleTypes(left, right, false)
+	return c.checkCompatibleTypes(left, right)
 }
 
-func (c typeChecker) checkCompatibleTypes(left, right ast.Expression, allowArrays bool) (valueType, error) {
-	return c.checkCompatibleTypesWith(c, left, right, allowArrays)
-}
-
-func (c typeChecker) checkCompatibleTypesWith(rightChecker typeChecker, left, right ast.Expression, allowArrays bool) (valueType, error) {
+func (c typeChecker) checkCompatibleTypes(left, right ast.Expression) (valueType, error) {
 	leftType, err := c.check(left)
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
 
-	rightType, err := rightChecker.check(right)
+	rightType, err := c.check(right)
 	if err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	if !allowArrays && leftType.kind == kindStringArray {
-		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", leftType.describe())
-	}
-	if !allowArrays && rightType.kind == kindStringArray {
-		return valueType{kind: kindUnknown}, validationError("unexpected type: expected scalar comparison operand but found %s", rightType.describe())
-	}
 	if leftType.kind == kindNull || leftType.kind == kindUnknown {
-		return rightType.withNull(), nil
+		return rightType, nil
 	}
 	if rightType.kind == kindNull || rightType.kind == kindUnknown {
-		return leftType.withNull(), nil
+		return leftType, nil
 	}
 	if leftType.kind == kindStringArray || rightType.kind == kindStringArray {
 		if leftType.kind != rightType.kind {
 			return valueType{kind: kindUnknown}, validationError("unexpected type: expected %s but found %s", leftType.describe(), rightType.describe())
 		}
-		return leftType.withNullabilityFrom(rightType), nil
+		return leftType, nil
 	}
 	if leftType.enum != nil {
-		if rightType.enum != nil {
-			if !leftType.enum.compatible(rightType.enum) {
-				return valueType{kind: kindUnknown}, validationError("unexpected type: expected %s but found %s", leftType.describe(), rightType.describe())
-			}
-			return leftType.withNullabilityFrom(rightType), nil
-		}
 		if err := c.expectAny(right, kindString, kindNull); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 		if literal, ok := staticStringLiteral(right); ok && !leftType.enum.includes(literal.Value) {
 			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(left))
 		}
-		return leftType.withNullabilityFrom(rightType), nil
-	}
-
-	if rightType.enum != nil && leftType.kind == kindString {
-		if literal, ok := staticStringLiteral(left); ok && !rightType.enum.includes(literal.Value) {
-			return valueType{kind: kindUnknown}, validationError("%q is not a valid `%s`", literal.Value, identifierName(right))
-		}
-		return rightType.withNullabilityFrom(leftType), nil
+		return leftType, nil
 	}
 
 	if err := c.expectAny(right, leftType.kind, kindNull); err != nil {
 		return valueType{kind: kindUnknown}, err
 	}
-	return leftType.withNullabilityFrom(rightType), nil
-}
-
-func (c typeChecker) withNonNullableVariable(name string) typeChecker {
-	typ, ok := c.variables[name]
-	if !ok || !typ.nullable {
-		return c
-	}
-
-	variables := make(map[string]valueType, len(c.variables))
-	for key, value := range c.variables {
-		variables[key] = value
-	}
-	typ.nullable = false
-	variables[name] = typ
-	c.variables = variables
-	return c
+	return leftType, nil
 }
 
 func (c typeChecker) expect(expr ast.Expression, expected valueKind) error {
@@ -278,12 +222,8 @@ func (c typeChecker) expectAny(expr ast.Expression, expected ...valueKind) error
 	if actual.kind == kindUnknown {
 		return nil
 	}
-	allowsNull := containsKind(expected, kindNull)
 	for _, expectedKind := range expected {
 		if actual.enum == nil && actual.kind == expectedKind {
-			if actual.nullable && !allowsNull {
-				continue
-			}
 			return nil
 		}
 	}
@@ -299,7 +239,7 @@ func (c typeChecker) expectArrayElement(expr ast.Expression) error {
 	if actual.kind == kindUnknown {
 		return nil
 	}
-	if actual.kind == kindString && !actual.nullable {
+	if actual.kind == kindString && actual.enum == nil {
 		return nil
 	}
 	return validationError("unexpected type: expected string but found %s", actual.describe())
@@ -314,7 +254,11 @@ func (c typeChecker) expectIncludesRight(expr ast.Expression) error {
 		return nil
 	}
 	switch actual.kind {
-	case kindString, kindRegexp, kindNull:
+	case kindString:
+		if actual.enum == nil {
+			return nil
+		}
+	case kindRegexp, kindNull:
 		return nil
 	}
 	return validationError("unexpected type: expected string, regular expression, or null but found %s", actual.describe())
@@ -388,7 +332,7 @@ func functionTypes() map[string]functionSignature {
 		},
 		"build.env": {
 			args: []valueKind{kindString},
-			ret:  nullableStringType(),
+			ret:  stringType(),
 		},
 	}
 }
@@ -397,14 +341,7 @@ func stringType() valueType {
 	return valueType{kind: kindString}
 }
 
-func nullableStringType() valueType {
-	return valueType{kind: kindString, nullable: true}
-}
-
 func stringTypeFor(value *string) valueType {
-	if value == nil {
-		return nullableStringType()
-	}
 	return stringType()
 }
 
@@ -416,14 +353,7 @@ func boolType() valueType {
 	return valueType{kind: kindBool}
 }
 
-func nullableBoolType() valueType {
-	return valueType{kind: kindBool, nullable: true}
-}
-
 func boolTypeFor(value *bool) valueType {
-	if value == nil {
-		return nullableBoolType()
-	}
 	return boolType()
 }
 
@@ -431,14 +361,7 @@ func stringArrayType() valueType {
 	return valueType{kind: kindStringArray}
 }
 
-func nullableStringArrayType() valueType {
-	return valueType{kind: kindStringArray, nullable: true}
-}
-
 func stringArrayTypeFor(values []string) valueType {
-	if values == nil {
-		return nullableStringArrayType()
-	}
 	return stringArrayType()
 }
 
@@ -454,11 +377,7 @@ func enumValueType(name string, values ...string) valueType {
 }
 
 func enumValueTypeFor(value *string, name string, values ...string) valueType {
-	typ := enumValueType(name, values...)
-	if value == nil {
-		typ.nullable = true
-	}
-	return typ
+	return enumValueType(name, values...)
 }
 
 func stepString(step *Step, value func(*Step) *string) *string {
@@ -470,39 +389,14 @@ func stepString(step *Step, value func(*Step) *string) *string {
 
 func (t valueType) describe() string {
 	if t.enum != nil {
-		if t.nullable {
-			return "nullable " + t.enum.name + " enumeration value"
-		}
 		return t.enum.name + " enumeration value"
 	}
-	if t.nullable {
-		return "nullable " + string(t.kind)
-	}
 	return string(t.kind)
-}
-
-func (t valueType) withNull() valueType {
-	if t.kind == kindUnknown {
-		return t
-	}
-	t.nullable = true
-	return t
-}
-
-func (t valueType) withNullabilityFrom(other valueType) valueType {
-	if other.kind == kindNull || other.nullable {
-		return t.withNull()
-	}
-	return t
 }
 
 func (e enumType) includes(value string) bool {
 	_, ok := e.values[value]
 	return ok
-}
-
-func (e enumType) compatible(other *enumType) bool {
-	return other != nil && e.name == other.name
 }
 
 func validationError(format string, args ...any) *Error {
@@ -528,15 +422,6 @@ func describeKinds(kinds []valueKind) string {
 	return out
 }
 
-func containsKind(kinds []valueKind, target valueKind) bool {
-	for _, kind := range kinds {
-		if kind == target {
-			return true
-		}
-	}
-	return false
-}
-
 func runtimeStringLiteral(literal *ast.StringLiteral) bool {
 	return literal.Token.Flags == `"` && evaluator.ContainsShellExpansion(literal.Value)
 }
@@ -547,63 +432,6 @@ func staticStringLiteral(expr ast.Expression) (*ast.StringLiteral, bool) {
 		return nil, false
 	}
 	return literal, true
-}
-
-func logicalExpressionShortCircuits(expr *ast.InfixExpression) bool {
-	left, ok := expr.Left.(*ast.Boolean)
-	if !ok {
-		return false
-	}
-
-	return (expr.Operator == "&&" && !left.Value) || (expr.Operator == "||" && left.Value)
-}
-
-func nonNullGuardForRHS(operator string, left ast.Expression) (string, bool) {
-	guard, ok := left.(*ast.InfixExpression)
-	if !ok {
-		return "", false
-	}
-	switch {
-	case operator == "&&" && guard.Operator == "!=":
-		return nullComparedIdentifier(guard.Left, guard.Right)
-	case operator == "||" && guard.Operator == "==":
-		return nullComparedIdentifier(guard.Left, guard.Right)
-	default:
-		return "", false
-	}
-}
-
-func nonNullGuardForConditional(condition ast.Expression) (name string, consequenceIsNonNull bool, ok bool) {
-	guard, ok := condition.(*ast.InfixExpression)
-	if !ok {
-		return "", false, false
-	}
-	name, ok = nullComparedIdentifier(guard.Left, guard.Right)
-	if !ok {
-		return "", false, false
-	}
-	switch guard.Operator {
-	case "!=":
-		return name, true, true
-	case "==":
-		return name, false, true
-	default:
-		return "", false, false
-	}
-}
-
-func nullComparedIdentifier(left, right ast.Expression) (string, bool) {
-	if _, ok := right.(*ast.Null); ok {
-		if ident, ok := left.(*ast.Identifier); ok {
-			return ident.Value, true
-		}
-	}
-	if _, ok := left.(*ast.Null); ok {
-		if ident, ok := right.(*ast.Identifier); ok {
-			return ident.Value, true
-		}
-	}
-	return "", false
 }
 
 func identifierName(expr ast.Expression) string {


### PR DESCRIPTION
The local type checker had drifted into modelling nullable unions and flow-sensitive null guards. The server does not do that. `Conditional::Variable.new(value, type:)` keeps the declared token type even when the runtime value is nil, and the server type checker still walks both sides of logical expressions before runtime short-circuiting can happen.

This brings the Go root API back to that server model. Typed nil Buildkite fields now validate as their declared type and evaluate falsey when the runtime value is nil. Enum values are no longer treated as plain strings for reversed comparisons or `includes` operands, and array equality/null comparisons follow the server's generic equality behavior.

Concrete behavior changes:

- `build.fixed` validates as a boolean even when its runtime value is nil, and evaluates to false through the Go `bool` API.
- `!build.pull_request.draft` remains valid and returns true when the draft value is nil.
- `false && missing.value == "x"` now fails validation, because the server type checker still checks the skipped branch.
- `"passed" == build.state`, `build.state == build.state`, and `["passed"] includes build.state` now fail validation because `build.state` is an enum token type.
- `["a"] == ["a"]`, `["a"] == null`, and `null == build.creator.teams` now use server-style equality semantics.

The parity plan is updated with the resolved Slice 4 semantics and the remaining gaps around exact string escape coverage, custom functions and lazy variables, the context matrix, and regex validator parity.
