### PR TITLE
fix: Match server string escapes

### DIFF
--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -343,8 +343,8 @@ Initial manifest:
 
 | Upstream source | Groups to account for | Current status | Required status before parity claim |
 | --- | --- | --- | --- |
-| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; Slice 4 starts double-quoted shell interpolation. Exact friendly messages, token positions, and full string escape parity remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
-| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 4 ports regex includes, null regex/includes semantics, shell substitution evaluation, double-quoted interpolation, enum literal validation, logical type-checking before runtime short-circuiting, enum comparison asymmetry, array equality/null comparisons, Ruby-style falsey runtime behavior for typed nil booleans, and representative type-checker rejection cases. Full custom function/lazy variable coverage remains | `ported` |
+| `spec/models/conditional/parser_spec.rb` | friendly errors, comments, objects/properties, function calls, complex strings, simple expressions, operand precedence, negation, token positions | `blocked`: Slice 3 ports flat dotted identifiers/functions, ternary precedence, shell expansion operands, malformed dotted-name rejection, and parser-level rejection of `@>`; Slice 4 ports server string escape decoding for single-quoted and double-quoted strings plus quote-aware shell fallback scanning. Exact friendly messages and token positions remain follow-up parser work | `ported` or `intentionally_excluded` with reason |
+| `spec/models/conditional/evaluator_spec.rb` | booleans, nulls, arrays, regexes, string comparisons, ternaries, variables/enums, shell substitutions | `blocked`: Slice 4 ports regex includes, null regex/includes semantics, shell substitution evaluation, double-quoted interpolation, server string escapes, shell fallback string grammar, enum literal validation, logical type-checking before runtime short-circuiting, enum comparison asymmetry, array equality/null comparisons, Ruby-style falsey runtime behavior for typed nil booleans, and representative type-checker rejection cases. Full custom function/lazy variable coverage remains | `ported` |
 | `spec/models/conditional/variable_spec.rb` | typed variables, nullable typed values, enums, lazy values | `blocked`: Slice 4 ports the server's declared-type behavior for nil values: typed nil strings, booleans, arrays, and enums type-check as their declared type rather than nullable unions. Lazy variable internals and exhaustive variable specs remain Slice 5/cleanup work | `ported` or `superseded` by Go type/context tests |
 | `spec/models/build/condition_spec.rb` | `env()`, `build.env()`, build/pipeline/org fields, webhook fields, pull request label, project env merge, validation, context construction | `blocked`: Slice 2 seeds source-tagged root cases for representative `env()`, `build.env()`, organization, pipeline, webhook, pull request label, project env merge, and validation behavior; the exhaustive context matrix is Slice 5 | `ported` |
 | `spec/validators/build_condition_validator_spec.rb` | blank/nil validation, invalid conditionals, step-variable validation option | `blocked`: Slice 2 ports blank string, invalid expression, step-variable rejection, and step-option acceptance through root validation; nil validation is not representable in the string API | `ported` or `intentionally_excluded` with reason |
@@ -393,6 +393,10 @@ from this plan.
   enum-to-static-string comparisons, logical operands are type-checked on both
   sides before runtime short-circuiting, and ternary branches do not create
   flow-sensitive nullable unions.
+- Slice 4 also ports server string escape semantics for single-quoted,
+  double-quoted, and shell fallback strings. String tokens now keep both decoded
+  values and raw source bodies so escaped dollars stay static while unescaped
+  shell substitutions still evaluate through the Buildkite environment.
 - Some landed behavior is still explicitly provisional because it diverges from
   the server regex validator or still lacks exhaustive custom function/lazy
   variable coverage.
@@ -417,8 +421,13 @@ from this plan.
 - Shell expansion operands now evaluate against the merged Buildkite
   environment for set, unset, empty, required, default, alternate, substring,
   nested substring argument, and bad substring length cases.
-- Double-quoted strings now evaluate shell substitutions, while single-quoted
-  strings keep shell-looking text literal.
+- Double-quoted strings now evaluate shell substitutions, collapse `$$` to a
+  literal dollar, and decode the server escape set. Single-quoted strings decode
+  only the server-supported `\\` and `\'` escapes and keep shell-looking text
+  literal.
+- Shell fallback strings now decode server escapes, support nested single- and
+  double-quoted fallback strings, and keep braces inside nested fallback quotes
+  from closing the surrounding `${...}` expression.
 - Server-supported cases that the current implementation cannot pass are not
   added as skipped tests. They remain recorded in the manifest and known gaps
   until the parser, evaluator, context, and regex parity slices implement them.
@@ -433,7 +442,7 @@ from this plan.
 | Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables. Some public implementation packages still expose older generic-language concepts during transition. | Finish removing nested object lookup assumptions and move implementation packages under `internal/` in the cleanup slice. |
 | `build.env()` | `build.env("NAME")` parses as a flat function identifier, type-checks with the server's string return token type, and evaluates to `null` for absent variables through the root adapter. | Expand validator and conformance coverage for the full server env matrix in Slice 5. |
 | Ternary syntax | Ternaries parse with server precedence, evaluate lazily, use Ruby truthiness for nil runtime conditions, and type-check branch compatibility without local nullable-union narrowing. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
-| Shell substitution | Shell expansion operands and double-quoted interpolation evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix. | Finish exact string escape parity, shell fallback string grammar coverage, and package-local parser/evaluator tests for edge cases beyond the current root tables. |
+| Shell substitution | Shell expansion operands, double-quoted interpolation, server string escapes, and quoted fallback strings evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix and representative fallback grammar cases. | Finish custom function/lazy variable coverage and expand the upstream parser/evaluator matrix until every shell substitution group is accounted for. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |
 | Nullable values | Documented nullable Buildkite assignments are present as runtime `null` while keeping their server-declared type for validation. Truly unknown variables still fail closed. | Finish the exhaustive context matrix and lazy variable coverage so every documented nullable field is covered in every entrypoint. |
 | Context restrictions | No context kind. | Enforce pipeline, step, build-notification, and step-notification variable availability. |
@@ -773,11 +782,15 @@ Current Slice 4 progress:
   values, empty values, and invalid substring lengths.
 - Double-quoted strings interpolate shell substitutions and collapse `$$` to a
   literal dollar. Single-quoted strings remain literal.
-- Remaining Slice 4 work before marking the slice landed: exact server string
-  escape parity across single-quoted, double-quoted, and shell fallback strings;
-  broader upstream type-checker cases for custom functions and lazy variables;
-  and package-local parser/evaluator tests for the substitution grammar beyond
-  the current root conformance tables.
+- String escape evaluation now matches the server grammar for single-quoted,
+  double-quoted, and shell fallback strings, including newline, space, control,
+  byte-oriented hex and octal escapes, out-of-range octal rejection, unknown
+  double-quoted escapes, single-quoted `\\`/`\'`, escaped dollars, and braces
+  inside nested quoted fallback strings.
+- Remaining Slice 4 work before marking the slice landed: broader upstream
+  type-checker cases for custom functions and lazy variables, plus a final pass
+  over the upstream evaluator/parser groups to ensure no substitution grammar
+  cases are unaccounted for.
 
 ### Slice 5: Buildkite Context And `env()` Semantics
 

--- a/eval_test.go
+++ b/eval_test.go
@@ -525,6 +525,70 @@ func TestConditionalShellSubstitutionEvaluation(t *testing.T) {
 			ctx:        ctx,
 			want:       false,
 		},
+		{
+			name:   "double quoted string escapes are decoded",
+			source: upstreamParserSpec,
+			expression: `"line\nfeed" == "line
+feed"`,
+			ctx:  ctx,
+			want: true,
+		},
+		{
+			name:       "double quoted hex and octal escapes are decoded",
+			source:     upstreamParserSpec,
+			expression: `"hex\x41 octal\141" == "hexA octala"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "single quoted unknown escapes stay literal",
+			source:     upstreamParserSpec,
+			expression: `'\n' == "\\n"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "double quoted escaped dollar after escaped slash stays literal",
+			source:     upstreamConditionalGrammar,
+			expression: `"\\\$branch" == '\$branch'`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "shell fallback decodes string escapes",
+			source:     upstreamConditionalGrammar,
+			expression: `${notset-\x41\svalue} == "A value"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "shell fallback removes nested double quotes",
+			source:     upstreamParserSpec,
+			expression: `${notset-"${branch}"} == "main"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "shell fallback preserves brace inside nested quotes",
+			source:     upstreamConditionalGrammar,
+			expression: `${notset-"}"} == "}"`,
+			ctx:        ctx,
+			want:       true,
+		},
+		{
+			name:       "shell fallback rejects out of range octal escape",
+			source:     upstreamConditionalGrammar,
+			expression: `${notset-\400} == ""`,
+			ctx:        ctx,
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "shell fallback removes nested single quotes",
+			source:     upstreamParserSpec,
+			expression: `${notset-'quoted fallback'} == "quoted fallback"`,
+			ctx:        ctx,
+			want:       true,
+		},
 	}
 
 	runEvaluateCases(t, tests)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -29,7 +29,7 @@ func Eval(node ast.Node, scope Scope) object.Object {
 		return &object.Integer{Value: node.Value}
 
 	case *ast.StringLiteral:
-		return evalStringLiteral(node.Value, node.Token.Flags, scope)
+		return evalStringLiteral(node.Value, node.Token.Raw, node.Token.Flags, scope)
 
 	case *ast.Regexp:
 		return &object.Regexp{Regexp: node.Regexp, Flags: node.Flags}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -263,6 +263,99 @@ func TestDoubleQuotedShellExpansionWithoutEnvironmentScopeRemainsLiteral(t *test
 	testBooleanObject(t, evaluated, true)
 }
 
+func TestContainsShellExpansionConsumesStringEscapes(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected bool
+	}{
+		{
+			name:     "unescaped variable expands",
+			raw:      `${branch}`,
+			expected: true,
+		},
+		{
+			name:     "escaped dollar stays literal",
+			raw:      `\$branch`,
+			expected: false,
+		},
+		{
+			name:     "dollar after escaped slash expands",
+			raw:      `\\$branch`,
+			expected: true,
+		},
+		{
+			name:     "escaped dollar after escaped slash stays literal",
+			raw:      `\\\$branch`,
+			expected: false,
+		},
+		{
+			name:     "hex escaped dollar stays literal",
+			raw:      `\x24branch`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		if got := ContainsShellExpansion(tt.raw); got != tt.expected {
+			t.Errorf("%s: ContainsShellExpansion(%q) = %t, want %t", tt.name, tt.raw, got, tt.expected)
+		}
+	}
+}
+
+func TestShellFallbackStringGrammar(t *testing.T) {
+	scope := shellTestScope{
+		Struct: object.Struct{},
+		env: map[string]string{
+			"branch": "main",
+		},
+	}
+
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{`${missing-\x41\svalue} == "A value"`, true},
+		{`${missing-"$branch"} == "main"`, true},
+		{`${missing-"}"} == "}"`, true},
+		{`${missing-'quoted fallback'} == "quoted fallback"`, true},
+		{`${missing-\q} == "q"`, true},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEvalWithScope(tt.input, scope)
+		testBooleanObject(t, evaluated, tt.expected)
+	}
+}
+
+func TestShellStringEscapesUseBytes(t *testing.T) {
+	got, err := evalShellString(`\xff\377`, shellTestScope{})
+	if err != nil {
+		t.Fatalf("evalShellString returned error: %v", err)
+	}
+
+	want := string([]byte{0xff, 0xff})
+	if got != want {
+		t.Fatalf("evalShellString bytes = %v, want %v", []byte(got), []byte(want))
+	}
+}
+
+func TestShellStringEscapesRejectOutOfRangeOctal(t *testing.T) {
+	if _, err := evalShellString(`\400`, shellTestScope{}); err == nil {
+		t.Fatal("evalShellString did not reject out-of-range octal escape")
+	}
+}
+
+type shellTestScope struct {
+	object.Struct
+	env map[string]string
+}
+
+func (s shellTestScope) LookupEnv(key string) (string, bool) {
+	value, ok := s.env[key]
+	return value, ok
+}
+
 func testEval(input string) object.Object {
 	return testEvalWithScope(input, object.Struct{})
 }

--- a/evaluator/shell.go
+++ b/evaluator/shell.go
@@ -31,8 +31,11 @@ func evalShellExpansion(raw string, scope Scope) object.Object {
 	return &object.String{Value: value}
 }
 
-func evalStringLiteral(value string, quote string, scope Scope) object.Object {
-	if quote != `"` || !ContainsShellTemplate(value) {
+func evalStringLiteral(value string, raw string, quote string, scope Scope) object.Object {
+	if raw == "" {
+		raw = value
+	}
+	if quote != `"` || !ContainsShellTemplate(raw) {
 		return &object.String{Value: value}
 	}
 
@@ -41,7 +44,7 @@ func evalStringLiteral(value string, quote string, scope Scope) object.Object {
 		return &object.String{Value: value}
 	}
 
-	out, err := evalShellString(value, env)
+	out, err := evalShellString(raw, env)
 	if err != nil {
 		return newError("%s", err.Error())
 	}
@@ -70,12 +73,9 @@ func ContainsShellExpansion(value string) bool {
 			}
 			i++
 		case '\\':
-			next := i
-			for next < len(value) && value[next] == '\\' {
-				next++
-			}
-			if next < len(value) && value[next] == '$' && next == i+1 {
-				i = next + 1
+			_, next, err := readShellStringEscape(value, i)
+			if err != nil {
+				i++
 				continue
 			}
 			i = next
@@ -223,6 +223,13 @@ func evalShellString(raw string, env EnvScope) (string, error) {
 	var out strings.Builder
 	for i := 0; i < len(raw); {
 		switch raw[i] {
+		case '"', '\'':
+			value, next, err := evalQuotedShellString(raw, i, env)
+			if err != nil {
+				return "", err
+			}
+			out.WriteString(value)
+			i = next
 		case '$':
 			if i+1 < len(raw) && raw[i+1] == '$' {
 				out.WriteByte('$')
@@ -244,16 +251,11 @@ func evalShellString(raw string, env EnvScope) (string, error) {
 			}
 			i = next
 		case '\\':
-			next := i
-			for next < len(raw) && raw[next] == '\\' {
-				next++
+			value, next, err := readShellStringEscape(raw, i)
+			if err != nil {
+				return "", err
 			}
-			if next < len(raw) && raw[next] == '$' && next == i+1 {
-				out.WriteByte('$')
-				i = next + 1
-				continue
-			}
-			out.WriteString(raw[i:next])
+			out.WriteString(value)
 			i = next
 		default:
 			out.WriteByte(raw[i])
@@ -261,6 +263,132 @@ func evalShellString(raw string, env EnvScope) (string, error) {
 		}
 	}
 	return out.String(), nil
+}
+
+func evalQuotedShellString(raw string, start int, env EnvScope) (string, int, error) {
+	quote := raw[start]
+	var out strings.Builder
+	for i := start + 1; i < len(raw); {
+		if raw[i] == quote {
+			return out.String(), i + 1, nil
+		}
+
+		if quote == '\'' {
+			if raw[i] == '\\' {
+				value, next, err := readSingleQuotedShellEscape(raw, i)
+				if err != nil {
+					return "", start, err
+				}
+				out.WriteString(value)
+				i = next
+				continue
+			}
+			out.WriteByte(raw[i])
+			i++
+			continue
+		}
+
+		switch raw[i] {
+		case '$':
+			if i+1 < len(raw) && raw[i+1] == '$' {
+				out.WriteByte('$')
+				i += 2
+				continue
+			}
+			expansion, next, ok := readShellExpansion(raw, i)
+			if !ok {
+				out.WriteByte('$')
+				i++
+				continue
+			}
+			value, set, err := evalShellRaw(expansion, env)
+			if err != nil {
+				return "", start, err
+			}
+			if set {
+				out.WriteString(value)
+			}
+			i = next
+		case '\\':
+			value, next, err := readShellStringEscape(raw, i)
+			if err != nil {
+				return "", start, err
+			}
+			out.WriteString(value)
+			i = next
+		default:
+			out.WriteByte(raw[i])
+			i++
+		}
+	}
+	return "", start, fmt.Errorf("unterminated shell string")
+}
+
+func readSingleQuotedShellEscape(raw string, start int) (string, int, error) {
+	if start+1 >= len(raw) {
+		return "", start, fmt.Errorf("unterminated shell string escape")
+	}
+	switch raw[start+1] {
+	case '\\', '\'':
+		return string(raw[start+1]), start + 2, nil
+	default:
+		return raw[start : start+2], start + 2, nil
+	}
+}
+
+func readShellStringEscape(raw string, start int) (string, int, error) {
+	if start+1 >= len(raw) {
+		return "", start, fmt.Errorf("unterminated shell string escape")
+	}
+
+	next := raw[start+1]
+	switch next {
+	case 'n':
+		return "\n", start + 2, nil
+	case 's':
+		return " ", start + 2, nil
+	case 'r':
+		return "\r", start + 2, nil
+	case 't':
+		return "\t", start + 2, nil
+	case 'v':
+		return "\v", start + 2, nil
+	case 'f':
+		return "\f", start + 2, nil
+	case 'b':
+		return "\b", start + 2, nil
+	case 'a':
+		return "\a", start + 2, nil
+	case 'e':
+		return "\x1b", start + 2, nil
+	case '\\', '"':
+		return string(next), start + 2, nil
+	case 'x':
+		if start+3 < len(raw) && isHexDigit(raw[start+2]) && isHexDigit(raw[start+3]) {
+			value, err := strconv.ParseInt(raw[start+2:start+4], 16, 32)
+			if err != nil {
+				return "", start, err
+			}
+			return string([]byte{byte(value)}), start + 4, nil
+		}
+		return "x", start + 2, nil
+	default:
+		if isOctalDigit(next) {
+			end := start + 2
+			for end < len(raw) && end < start+4 && isOctalDigit(raw[end]) {
+				end++
+			}
+			value, err := strconv.ParseInt(raw[start+1:end], 8, 32)
+			if err != nil {
+				return "", start, err
+			}
+			if value > 0xff {
+				return "", start, fmt.Errorf("octal escape out of range: \\%s", raw[start+1:end])
+			}
+			return string([]byte{byte(value)}), end, nil
+		}
+		return string(next), start + 2, nil
+	}
 }
 
 func splitShellName(inner string) (name string, rest string, ok bool) {
@@ -288,6 +416,18 @@ func splitTopLevel(raw string, separator byte) []string {
 	start := 0
 	depth := 0
 	for i := 0; i < len(raw); i++ {
+		if raw[i] == '\\' {
+			i++
+			continue
+		}
+		if raw[i] == '"' || raw[i] == '\'' {
+			next, ok := skipShellQuoted(raw, i)
+			if !ok {
+				continue
+			}
+			i = next - 1
+			continue
+		}
 		if raw[i] == '$' && i+1 < len(raw) && raw[i+1] == '{' {
 			depth++
 			i++
@@ -326,6 +466,18 @@ func readShellExpansion(raw string, start int) (string, int, bool) {
 
 	depth := 1
 	for i := start + 2; i < len(raw); i++ {
+		if raw[i] == '\\' {
+			i++
+			continue
+		}
+		if raw[i] == '"' || raw[i] == '\'' {
+			next, ok := skipShellQuoted(raw, i)
+			if !ok {
+				return "", start, false
+			}
+			i = next - 1
+			continue
+		}
 		if raw[i] == '$' && i+1 < len(raw) && raw[i+1] == '{' {
 			depth++
 			i++
@@ -341,10 +493,33 @@ func readShellExpansion(raw string, start int) (string, int, bool) {
 	return "", start, false
 }
 
+func skipShellQuoted(raw string, start int) (int, bool) {
+	quote := raw[start]
+	escaped := false
+	for i := start + 1; i < len(raw); i++ {
+		if raw[i] == quote && !escaped {
+			return i + 1, true
+		}
+		escaped = raw[i] == '\\' && !escaped
+		if raw[i] != '\\' {
+			escaped = false
+		}
+	}
+	return start, false
+}
+
 func isShellIdentStart(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
 }
 
 func isShellIdentPart(ch byte) bool {
 	return isShellIdentStart(ch) || (ch >= '0' && ch <= '9')
+}
+
+func isOctalDigit(ch byte) bool {
+	return ch >= '0' && ch <= '7'
+}
+
+func isHexDigit(ch byte) bool {
+	return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F')
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,6 +1,9 @@
 package lexer
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/buildkite/conditional/token"
 )
 
@@ -93,19 +96,21 @@ func (l *Lexer) NextToken() token.Token {
 	case '"':
 		tok.Type = token.STRING
 		var terminated bool
-		tok.Literal, terminated = l.readString('"')
+		tok.Literal, tok.Raw, terminated = l.readString('"')
 		tok.Flags = `"`
 		if !terminated {
 			tok.Type = token.ILLEGAL
+			tok.Literal = tok.Raw
 			tok.Flags = ""
 		}
 	case '\'':
 		tok.Type = token.STRING
 		var terminated bool
-		tok.Literal, terminated = l.readString('\'')
+		tok.Literal, tok.Raw, terminated = l.readString('\'')
 		tok.Flags = `'`
 		if !terminated {
 			tok.Type = token.ILLEGAL
+			tok.Literal = tok.Raw
 			tok.Flags = ""
 		}
 	case '/':
@@ -202,22 +207,122 @@ func (l *Lexer) readNumber() string {
 	return l.input[position:l.position]
 }
 
-func (l *Lexer) readString(quote byte) (string, bool) {
+func (l *Lexer) readString(quote byte) (string, string, bool) {
 	position := l.position + 1
-	escaped := false
+	var out strings.Builder
 	for {
 		l.readChar()
 		if l.ch == 0 {
-			return l.input[position:l.position], false
+			return out.String(), l.input[position:l.position], false
 		}
-		if l.ch == quote && !escaped {
-			return l.input[position:l.position], true
+		if l.ch == quote {
+			return out.String(), l.input[position:l.position], true
 		}
-		escaped = l.ch == '\\' && !escaped
 		if l.ch != '\\' {
-			escaped = false
+			out.WriteByte(l.ch)
+			continue
+		}
+
+		if quote == '\'' {
+			if !l.readSingleQuotedEscape(&out) {
+				return out.String(), l.input[position:l.position], false
+			}
+			continue
+		}
+		if !l.readStringEscape(&out) {
+			return out.String(), l.input[position:l.position], false
 		}
 	}
+}
+
+func (l *Lexer) readSingleQuotedEscape(out *strings.Builder) bool {
+	l.readChar()
+	if l.ch == 0 {
+		return false
+	}
+	switch l.ch {
+	case '\\', '\'':
+		out.WriteByte(l.ch)
+	default:
+		out.WriteByte('\\')
+		out.WriteByte(l.ch)
+	}
+	return true
+}
+
+func (l *Lexer) readStringEscape(out *strings.Builder) bool {
+	l.readChar()
+	if l.ch == 0 {
+		return false
+	}
+
+	switch l.ch {
+	case 'n':
+		out.WriteByte('\n')
+	case 's':
+		out.WriteByte(' ')
+	case 'r':
+		out.WriteByte('\r')
+	case 't':
+		out.WriteByte('\t')
+	case 'v':
+		out.WriteByte('\v')
+	case 'f':
+		out.WriteByte('\f')
+	case 'b':
+		out.WriteByte('\b')
+	case 'a':
+		out.WriteByte('\a')
+	case 'e':
+		out.WriteByte('\x1b')
+	case '\\', '"':
+		out.WriteByte(l.ch)
+	case 'x':
+		if l.readHexEscape(out) {
+			return true
+		}
+		out.WriteByte('x')
+	default:
+		if isOctalDigit(l.ch) {
+			return l.readOctalEscape(out)
+		}
+		out.WriteByte(l.ch)
+	}
+	return true
+}
+
+func (l *Lexer) readHexEscape(out *strings.Builder) bool {
+	if l.readPosition+1 >= len(l.input) {
+		return false
+	}
+	if !isHexDigit(l.input[l.readPosition]) || !isHexDigit(l.input[l.readPosition+1]) {
+		return false
+	}
+
+	digits := l.input[l.readPosition : l.readPosition+2]
+	value, err := strconv.ParseInt(digits, 16, 32)
+	if err != nil {
+		return false
+	}
+	l.readChar()
+	l.readChar()
+	out.WriteByte(byte(value))
+	return true
+}
+
+func (l *Lexer) readOctalEscape(out *strings.Builder) bool {
+	digits := []byte{l.ch}
+	for len(digits) < 3 && l.readPosition < len(l.input) && isOctalDigit(l.input[l.readPosition]) {
+		l.readChar()
+		digits = append(digits, l.ch)
+	}
+
+	value, err := strconv.ParseInt(string(digits), 8, 32)
+	if err != nil || value > 0xff {
+		return false
+	}
+	out.WriteByte(byte(value))
+	return true
 }
 
 func (l *Lexer) readShell() (string, bool) {
@@ -248,6 +353,10 @@ func (l *Lexer) readShell() (string, bool) {
 		case l.ch == '\\' && !escaped:
 			escaped = true
 			continue
+		case (l.ch == '"' || l.ch == '\'') && !escaped:
+			if !l.skipRawQuotedString(l.ch) {
+				return l.input[position:l.position], false
+			}
 		case l.ch == '{' && !escaped:
 			depth++
 		case l.ch == '}' && !escaped:
@@ -259,6 +368,23 @@ func (l *Lexer) readShell() (string, bool) {
 		}
 
 		escaped = false
+	}
+}
+
+func (l *Lexer) skipRawQuotedString(quote byte) bool {
+	escaped := false
+	for {
+		l.readChar()
+		if l.ch == 0 {
+			return false
+		}
+		if l.ch == quote && !escaped {
+			return true
+		}
+		escaped = l.ch == '\\' && !escaped
+		if l.ch != '\\' {
+			escaped = false
+		}
 	}
 }
 
@@ -310,6 +436,14 @@ func isIdentPart(ch byte) bool {
 
 func isDigit(ch byte) bool {
 	return '0' <= ch && ch <= '9'
+}
+
+func isOctalDigit(ch byte) bool {
+	return '0' <= ch && ch <= '7'
+}
+
+func isHexDigit(ch byte) bool {
+	return isDigit(ch) || ('a' <= ch && ch <= 'f') || ('A' <= ch && ch <= 'F')
 }
 
 func newToken(tokenType token.TokenType, ch byte) token.Token {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -35,6 +35,33 @@ func TestLexingUnterminatedStrings(t *testing.T) {
 	})
 }
 
+func TestLexingStringEscapes(t *testing.T) {
+	expectTokens(t, `"line\nfeed"`, []tokenExpectation{
+		{token.STRING, "line\nfeed"},
+	})
+	expectTokens(t, `"space\sescape"`, []tokenExpectation{
+		{token.STRING, "space escape"},
+	})
+	expectTokens(t, `"hex\x41 octal\141"`, []tokenExpectation{
+		{token.STRING, "hexA octala"},
+	})
+	expectTokens(t, `"byte\xff octal\377"`, []tokenExpectation{
+		{token.STRING, "byte" + string([]byte{0xff}) + " octal" + string([]byte{0xff})},
+	})
+	expectTokens(t, `"unknown\qescape"`, []tokenExpectation{
+		{token.STRING, "unknownqescape"},
+	})
+	expectTokens(t, `'listening to \'music\''`, []tokenExpectation{
+		{token.STRING, "listening to 'music'"},
+	})
+	expectTokens(t, `'\n stays literal'`, []tokenExpectation{
+		{token.STRING, `\n stays literal`},
+	})
+	expectTokens(t, `'\\ becomes slash'`, []tokenExpectation{
+		{token.STRING, `\ becomes slash`},
+	})
+}
+
 func TestLexingValueComparisons(t *testing.T) {
 	expectTokens(t, `build.branch == "master"`, []tokenExpectation{
 		{token.IDENT, "build.branch"},

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -102,6 +102,12 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindParse,
 		},
 		{
+			name:       "parse error for out of range octal string escape",
+			source:     upstreamConditionalGrammar,
+			expression: `"\400" == ""`,
+			wantError:  ErrorKindParse,
+		},
+		{
 			name:       "parser rejects local-only contains operator",
 			source:     upstreamParserSpec,
 			expression: `["main"] @> build.branch`,
@@ -187,6 +193,12 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			name:       "validation rejects invalid enum literal",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.state == "faillled"`,
+			wantError:  ErrorKindValidation,
+		},
+		{
+			name:       "validation rejects escaped static dollar enum literal",
+			source:     upstreamConditionalGrammar,
+			expression: `build.state == "\\\$STATE"`,
 			wantError:  ErrorKindValidation,
 		},
 		{

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -7,6 +7,7 @@ const (
 
 	upstreamParserSpec              = "buildkite/buildkite:spec/models/conditional/parser_spec.rb"
 	upstreamEvaluatorSpec           = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
+	upstreamConditionalGrammar      = "buildkite/buildkite:app/models/conditional/grammar.kpeg"
 	upstreamConditionalVariableSpec = "buildkite/buildkite:spec/models/conditional/variable_spec.rb"
 	upstreamBuildConditionSpec      = "buildkite/buildkite:spec/models/build/condition_spec.rb"
 	upstreamBuildValidatorSpec      = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"

--- a/token/token.go
+++ b/token/token.go
@@ -47,6 +47,7 @@ type Token struct {
 	Type    TokenType
 	Literal string
 	Flags   string
+	Raw     string
 }
 
 var keywords = map[string]TokenType{

--- a/typecheck.go
+++ b/typecheck.go
@@ -423,7 +423,11 @@ func describeKinds(kinds []valueKind) string {
 }
 
 func runtimeStringLiteral(literal *ast.StringLiteral) bool {
-	return literal.Token.Flags == `"` && evaluator.ContainsShellExpansion(literal.Value)
+	raw := literal.Token.Raw
+	if raw == "" {
+		raw = literal.Value
+	}
+	return literal.Token.Flags == `"` && evaluator.ContainsShellExpansion(raw)
 }
 
 func staticStringLiteral(expr ast.Expression) (*ast.StringLiteral, bool) {


### PR DESCRIPTION
String literals and shell fallback text were still using local escape behavior in a few places, which meant the Go parser could drift from the server grammar around escaped dollars, quoted fallback strings, and byte escapes.

This keeps both the decoded string value and the raw source body on string tokens. Validation can now treat `\$FOO` as a static dollar-prefixed string while unescaped `${FOO}` still evaluates through the Buildkite environment. Hex and octal escapes use the server's byte-oriented behavior, including rejecting octal values above `\377`.

Examples covered:

- `"line\nfeed"` decodes to an actual newline.
- `"\\\$branch"` stays a literal `\$branch`.
- `${missing-"}"}` evaluates to `}` without closing the surrounding substitution early.