### PR TITLE
fix: Validate runtime env names

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -298,6 +298,12 @@ func envNameArg(args []object.Object) (string, *object.Error) {
 	if !ok {
 		return "", &object.Error{Message: "env argument must be a string"}
 	}
+	if name.Value == "" {
+		return "", &object.Error{Message: "env argument should be an environment variable name"}
+	}
+	if unsupportedBuildkiteEnv(name.Value) {
+		return "", &object.Error{Message: fmt.Sprintf("interpolation of %q is not supported", name.Value)}
+	}
 	return name.Value, nil
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -394,6 +394,19 @@ func TestBuildkiteEnvironmentFunctions(t *testing.T) {
 			wantError: ErrorKindEvaluation,
 		},
 		{
+			name:       "indirect custom env name uses runtime lookup",
+			source:     upstreamBuildPipelineEnvModel,
+			expression: `env(env("SECRET_NAME")) == "value" && build.env(env("SECRET_NAME")) == "value"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv: map[string]string{
+					"SECRET_NAME": "FOO-BAR",
+					"FOO-BAR":     "value",
+				},
+			},
+			want: true,
+		},
+		{
 			name:       "missing indirect env name fails closed",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.env(env("MISSING_SECRET_NAME")) == null`,

--- a/context_test.go
+++ b/context_test.go
@@ -371,9 +371,9 @@ func TestBuildkiteEnvironmentFunctions(t *testing.T) {
 			want: true,
 		},
 		{
-			name:       "unsupported Buildkite env is filtered when indirect",
+			name:       "indirect unsupported Buildkite env fails closed",
 			source:     upstreamBuildConditionSpec,
-			expression: `build.env(env("SECRET_NAME")) == null && env(env("SECRET_NAME")) == ""`,
+			expression: `build.env(env("SECRET_NAME")) == null`,
 			ctx: Context{
 				EntryPoint: EntryPointBuildCondition,
 				BuildEnv: map[string]string{
@@ -381,7 +381,37 @@ func TestBuildkiteEnvironmentFunctions(t *testing.T) {
 					"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
 				},
 			},
-			want: true,
+			wantError: ErrorKindEvaluation,
+		},
+		{
+			name:       "indirect blank env name fails closed",
+			source:     upstreamBuildConditionSpec,
+			expression: `env(env("SECRET_NAME")) == ""`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				BuildEnv:   map[string]string{"SECRET_NAME": ""},
+			},
+			wantError: ErrorKindEvaluation,
+		},
+		{
+			name:       "missing indirect env name fails closed",
+			source:     upstreamBuildConditionSpec,
+			expression: `build.env(env("MISSING_SECRET_NAME")) == null`,
+			ctx:        Context{EntryPoint: EntryPointBuildCondition},
+			wantError:  ErrorKindEvaluation,
+		},
+		{
+			name:       "build notification false for indirect unsupported env",
+			source:     upstreamBuildNotificationSpec,
+			expression: `env(env("SECRET_NAME")) == "secret"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildNotification,
+				BuildEnv: map[string]string{
+					"SECRET_NAME":                  "BUILDKITE_AGENT_ACCESS_TOKEN",
+					"BUILDKITE_AGENT_ACCESS_TOKEN": "secret",
+				},
+			},
+			want: false,
 		},
 	}
 

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -397,6 +397,9 @@ from this plan.
   double-quoted, and shell fallback strings. String tokens now keep both decoded
   values and raw source bodies so escaped dollars stay static while unescaped
   shell substitutions still evaluate through the Buildkite environment.
+- Runtime `env()` and `build.env()` calls now enforce the server's blank-name
+  and `BUILDKITE_*` allowlist checks after interpolation, so dynamic names fail
+  closed the same way static literal names do.
 - Some landed behavior is still explicitly provisional because it diverges from
   the server regex validator or still lacks exhaustive custom function/lazy
   variable coverage.
@@ -428,6 +431,10 @@ from this plan.
 - Shell fallback strings now decode server escapes, support nested single- and
   double-quoted fallback strings, and keep braces inside nested fallback quotes
   from closing the surrounding `${...}` expression.
+- `env()` and `build.env()` now reject blank dynamic names and unsupported
+  dynamic `BUILDKITE_*` names during evaluation. Notification entrypoints still
+  convert those evaluation errors to `false`, matching the server deliverability
+  paths.
 - Server-supported cases that the current implementation cannot pass are not
   added as skipped tests. They remain recorded in the manifest and known gaps
   until the parser, evaluator, context, and regex parity slices implement them.
@@ -440,7 +447,7 @@ from this plan.
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
 | Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables. Some public implementation packages still expose older generic-language concepts during transition. | Finish removing nested object lookup assumptions and move implementation packages under `internal/` in the cleanup slice. |
-| `build.env()` | `build.env("NAME")` parses as a flat function identifier, type-checks with the server's string return token type, and evaluates to `null` for absent variables through the root adapter. | Expand validator and conformance coverage for the full server env matrix in Slice 5. |
+| `build.env()` | `build.env("NAME")` parses as a flat function identifier, type-checks with the server's string return token type, evaluates to `null` for absent variables, and fails closed for blank or unsupported dynamic `BUILDKITE_*` names. | Expand validator and conformance coverage for the full server env matrix in Slice 5. |
 | Ternary syntax | Ternaries parse with server precedence, evaluate lazily, use Ruby truthiness for nil runtime conditions, and type-check branch compatibility without local nullable-union narrowing. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
 | Shell substitution | Shell expansion operands, double-quoted interpolation, server string escapes, and quoted fallback strings evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix and representative fallback grammar cases. | Finish custom function/lazy variable coverage and expand the upstream parser/evaluator matrix until every shell substitution group is accounted for. |
 | Scope | Callers pass arbitrary `object.Struct`. | Add server-style Buildkite assignment tables with documented variables and context availability. |
@@ -787,6 +794,10 @@ Current Slice 4 progress:
   byte-oriented hex and octal escapes, out-of-range octal rejection, unknown
   double-quoted escapes, single-quoted `\\`/`\'`, escaped dollars, and braces
   inside nested quoted fallback strings.
+- Runtime environment function arguments now mirror the server after string
+  interpolation: blank names and unsupported `BUILDKITE_*` names produce
+  evaluation errors for build conditions and `false` for notification
+  deliverability checks.
 - Remaining Slice 4 work before marking the slice landed: broader upstream
   type-checker cases for custom functions and lazy variables, plus a final pass
   over the upstream evaluator/parser groups to ensure no substitution grammar

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -797,7 +797,7 @@ Current Slice 4 progress:
 - Runtime environment function arguments now mirror the server after string
   interpolation: blank names and unsupported `BUILDKITE_*` names produce
   evaluation errors for build conditions and `false` for notification
-  deliverability checks.
+  deliverability checks, while dynamic custom names remain runtime lookups.
 - Remaining Slice 4 work before marking the slice landed: broader upstream
   type-checker cases for custom functions and lazy variables, plus a final pass
   over the upstream evaluator/parser groups to ensure no substitution grammar

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -9,6 +9,7 @@ const (
 	upstreamEvaluatorSpec           = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
 	upstreamConditionalGrammar      = "buildkite/buildkite:app/models/conditional/grammar.kpeg"
 	upstreamConditionalVariableSpec = "buildkite/buildkite:spec/models/conditional/variable_spec.rb"
+	upstreamBuildPipelineEnvModel   = "buildkite/buildkite:app/models/build/pipeline_environment.rb"
 	upstreamBuildConditionSpec      = "buildkite/buildkite:spec/models/build/condition_spec.rb"
 	upstreamBuildValidatorSpec      = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
 	upstreamBuildNotificationSpec   = "buildkite/buildkite:spec/models/build/notification_spec.rb"


### PR DESCRIPTION
Dynamic `env()` and `build.env()` arguments could bypass the Buildkite env allowlist because validation only looked at static string literals. That let expressions build an unsupported `BUILDKITE_*` name at runtime and quietly get `""` or `null` instead of failing closed.

This makes the runtime function path enforce the same server boundary after interpolation. Blank dynamic names now fail, and unsupported `BUILDKITE_*` names return an evaluation error for build conditions. Notification entrypoints still collapse those errors to `false`, matching the server deliverability path.

Examples covered:

- `build.env(env("SECRET_NAME"))` fails when `SECRET_NAME` resolves to `BUILDKITE_AGENT_ACCESS_TOKEN`.
- `build.env(env("MISSING_SECRET_NAME"))` fails because the inner `env()` result is blank.
- Build notification conditionals return `false` for the same runtime failure.