### PR TITLE
fix: Drop unsupported pipeline name variable

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -346,7 +346,6 @@ func flatAssignments(ctx Context) object.Struct {
 		"build.merge_queue.base_branch":      stringValue(build.MergeQueue.BaseBranch),
 		"build.merge_queue.base_commit":      stringValue(build.MergeQueue.BaseCommit),
 		"pipeline.id":                        stringValue(ctx.Pipeline.ID),
-		"pipeline.name":                      stringValue(ctx.Pipeline.Name),
 		"pipeline.slug":                      stringValue(ctx.Pipeline.Slug),
 		"pipeline.default_branch":            stringValue(ctx.Pipeline.DefaultBranch),
 		"pipeline.repository":                stringValue(ctx.Pipeline.Repository),
@@ -432,7 +431,6 @@ func actorObject(actor Actor, includeVerified bool) object.Struct {
 func pipelineObject(pipeline Pipeline) object.Struct {
 	return object.Struct{
 		"id":                         stringValue(pipeline.ID),
-		"name":                       stringValue(pipeline.Name),
 		"slug":                       stringValue(pipeline.Slug),
 		"default_branch":             stringValue(pipeline.DefaultBranch),
 		"repository":                 stringValue(pipeline.Repository),

--- a/context_test.go
+++ b/context_test.go
@@ -555,6 +555,16 @@ func TestBuildkiteContextValidation(t *testing.T) {
 			ctx:        Context{EntryPoint: EntryPointBuildConditionWithStep},
 		},
 		{
+			name:       "pipeline name is not a server conditional variable",
+			source:     upstreamBuildConditionSpec,
+			expression: `pipeline.name == "Deploy"`,
+			ctx: Context{
+				EntryPoint: EntryPointBuildCondition,
+				Pipeline:   Pipeline{Name: str("Deploy")},
+			},
+			wantError: ErrorKindValidation,
+		},
+		{
 			name:       "literal unsupported Buildkite env is rejected",
 			source:     upstreamBuildConditionSpec,
 			expression: `build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`,

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -292,6 +292,11 @@ are derived in-library when the server does so, such as `build.source_event`
 from `Build.SourceEvent` or `BUILDKITE_GITHUB_EVENT` when
 `Build.Source == "webhook"`.
 
+Some public context fields exist only to derive supported built-in environment
+values. For example, `Pipeline.Name` feeds
+`build.env("BUILDKITE_PIPELINE_NAME")`, but `pipeline.name` is not a server
+conditional variable and must fail validation.
+
 Environment merge behavior is part of the public contract:
 
 - `ProjectEnv` and `BuildEnv` are merged using server-compatible precedence.
@@ -865,6 +870,9 @@ Current Slice 5 progress:
   pipeline, organization, pull request, merge queue, triggered-from,
   rebuilt-from, pull request labels and merge-refspec state, and merge-queue
   git-diff-base fields.
+- `pipeline.name` has been removed from the conditional variable surface
+  because `Build::Condition` does not assign it; `Pipeline.Name` remains as
+  caller-provided data for `BUILDKITE_PIPELINE_NAME`.
 - `BUILDKITE_GIT_DIFF_BASE` is gated by explicit merge-queue build state, then
   uses either the merge queue base branch or base commit according to the
   pipeline provider setting.

--- a/typecheck.go
+++ b/typecheck.go
@@ -301,7 +301,6 @@ func variableTypes(ctx Context) map[string]valueType {
 		"build.merge_queue.base_branch":       stringTypeFor(ctx.Build.MergeQueue.BaseBranch),
 		"build.merge_queue.base_commit":       stringTypeFor(ctx.Build.MergeQueue.BaseCommit),
 		"pipeline.id":                         stringTypeFor(ctx.Pipeline.ID),
-		"pipeline.name":                       stringTypeFor(ctx.Pipeline.Name),
 		"pipeline.slug":                       stringTypeFor(ctx.Pipeline.Slug),
 		"pipeline.default_branch":             stringTypeFor(ctx.Pipeline.DefaultBranch),
 		"pipeline.repository":                 stringTypeFor(ctx.Pipeline.Repository),


### PR DESCRIPTION
`pipeline.name` was a local-only conditional variable. Buildkite's server assignment table exposes `pipeline.id`, `pipeline.slug`, `pipeline.default_branch`, `pipeline.repository`, and the pipeline transition booleans, but not `pipeline.name`. Keeping it would make this library accept conditionals that the server rejects.

This removes `pipeline.name` from the root assignment and type-check tables, and adds a validation case proving it fails closed even when `Pipeline.Name` is set. `Pipeline.Name` remains in the public context because it is still needed to derive `build.env("BUILDKITE_PIPELINE_NAME")`.

The parity plan now records that some public context fields exist only for derived built-in environment values, not as conditional variables.