### PR TITLE
fix: Align conditional state enums

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -636,6 +636,26 @@ func TestBuildkiteEntrypoints(t *testing.T) {
 			want: true,
 		},
 		{
+			name:       "step notification accepts waiting for input state",
+			source:     upstreamStepStateMachineModel,
+			expression: `step.state == "waiting_for_input"`,
+			ctx: Context{
+				EntryPoint: EntryPointStepNotification,
+				Step:       &Step{State: str("waiting_for_input")},
+			},
+			want: true,
+		},
+		{
+			name:       "step notification accepts canceled state",
+			source:     upstreamStepStateMachineModel,
+			expression: `step.state == "canceled"`,
+			ctx: Context{
+				EntryPoint: EntryPointStepNotification,
+				Step:       &Step{State: str("canceled")},
+			},
+			want: true,
+		},
+		{
 			name:       "build condition with step can use step variables",
 			source:     upstreamBuildConditionSpec,
 			expression: `step.key == "deploy"`,

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -297,6 +297,10 @@ values. For example, `Pipeline.Name` feeds
 `build.env("BUILDKITE_PIPELINE_NAME")`, but `pipeline.name` is not a server
 conditional variable and must fail validation.
 
+Enum validation follows the server enum definitions when the public docs differ.
+For example, `pipeline.started_failing` is a boolean conditional variable, but
+`started_failing` is not a `Build::State` value in `Build::Condition`.
+
 Environment merge behavior is part of the public contract:
 
 - `ProjectEnv` and `BuildEnv` are merged using server-compatible precedence.
@@ -873,6 +877,9 @@ Current Slice 5 progress:
 - `pipeline.name` has been removed from the conditional variable surface
   because `Build::Condition` does not assign it; `Pipeline.Name` remains as
   caller-provided data for `BUILDKITE_PIPELINE_NAME`.
+- `build.state` and `step.state` enum validation now tracks the server enum
+  models for current drift: `build.state` rejects `started_failing`, while
+  `step.state` accepts `waiting_for_input` and `canceled`.
 - `BUILDKITE_GIT_DIFF_BASE` is gated by explicit merge-queue build state, then
   uses either the merge queue base branch or base commit according to the
   pipeline provider setting.

--- a/eval_test.go
+++ b/eval_test.go
@@ -126,13 +126,13 @@ func TestConditionalEvaluationSemantics(t *testing.T) {
 			wantError: ErrorKindValidation,
 		},
 		{
-			name:       "documented started failing build state",
-			source:     docsConditionalsSource,
+			name:       "server rejects pipeline transition value as build state",
+			source:     upstreamBuildModel,
 			expression: `build.state == "started_failing"`,
 			ctx: Context{
 				Build: Build{State: str("started_failing")},
 			},
-			want: true,
+			wantError: ErrorKindValidation,
 		},
 		{
 			name:       "documented started build state",

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -10,10 +10,12 @@ const (
 	upstreamConditionalGrammar      = "buildkite/buildkite:app/models/conditional/grammar.kpeg"
 	upstreamConditionalVariableSpec = "buildkite/buildkite:spec/models/conditional/variable_spec.rb"
 	upstreamBuildPipelineEnvModel   = "buildkite/buildkite:app/models/build/pipeline_environment.rb"
+	upstreamBuildModel              = "buildkite/buildkite:app/models/build.rb"
 	upstreamBuildConditionSpec      = "buildkite/buildkite:spec/models/build/condition_spec.rb"
 	upstreamBuildValidatorSpec      = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
 	upstreamBuildNotificationSpec   = "buildkite/buildkite:spec/models/build/notification_spec.rb"
 	upstreamStepNotificationSpec    = "buildkite/buildkite:spec/models/step/notification_spec.rb"
+	upstreamStepStateMachineModel   = "buildkite/buildkite:app/models/step/state_machine.rb"
 	upstreamConditionalRegexpModel  = "buildkite/buildkite:app/models/conditional/regexp.rb"
 )
 

--- a/typecheck.go
+++ b/typecheck.go
@@ -267,7 +267,7 @@ func (c typeChecker) expectIncludesRight(expr ast.Expression) error {
 func variableTypes(ctx Context) map[string]valueType {
 	variables := map[string]valueType{
 		"build.id":                            stringTypeFor(ctx.Build.ID),
-		"build.state":                         enumValueTypeFor(ctx.Build.State, "build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "started_failing", "canceling", "canceled", "skipped", "not_run"),
+		"build.state":                         enumValueTypeFor(ctx.Build.State, "build state", "creating", "started", "running", "scheduled", "blocked", "passed", "failing", "failed", "canceling", "canceled", "skipped", "not_run"),
 		"build.fixed":                         boolTypeFor(ctx.Build.Fixed),
 		"build.blocked_state":                 enumValueTypeFor(ctx.Build.BlockedState, "build blocked state", "failed", "passed", "running"),
 		"build.source":                        enumValueTypeFor(ctx.Build.Source, "build source", "api", "ui", "webhook", "trigger_job", "schedule", "pipeline_trigger"),
@@ -316,7 +316,7 @@ func variableTypes(ctx Context) map[string]valueType {
 		variables["step.key"] = stringTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Key }))
 		variables["step.type"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Type }), "step type", "command", "wait", "input", "trigger", "group")
 		variables["step.label"] = stringTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Label }))
-		variables["step.state"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.State }), "step state", "ignored", "waiting_for_dependencies", "ready", "running", "failing", "finished")
+		variables["step.state"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.State }), "step state", "ignored", "waiting_for_dependencies", "ready", "waiting_for_input", "running", "failing", "canceled", "finished")
 		variables["step.outcome"] = enumValueTypeFor(stepString(ctx.Step, func(step *Step) *string { return step.Outcome }), "step outcome", "neutral", "passed", "soft_failed", "hard_failed", "errored")
 	}
 


### PR DESCRIPTION
The enum validator was drifting from the server models. `Build::Condition` builds enum types from `Build::State` and `Step::StateMachine::State`, so the Go table needs to follow those models even when the docs lag or phrase things differently.

This removes `started_failing` from the `build.state` enum. That transition remains available as the boolean `pipeline.started_failing`, matching the server assignment table. It also adds the missing step states `waiting_for_input` and `canceled`, both of which are real `Step::StateMachine::State` values.

The tests now source these cases from the upstream model files, and the parity plan records the docs/server conflict so this does not get reintroduced while filling out the context matrix.