### PR TITLE
fix: Reject unsupported regex features

### DIFF
--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -956,6 +956,10 @@ Current Slice 6 progress:
 - Source-tagged regex validation tests cover those rejected constructs and guard
   that escaped text and character class contents are not mistaken for regex
   features.
+- Review hardening now covers RE2-style `(?P<name>...)` named captures, POSIX
+  classes followed by literal unsupported-looking tokens, leading literal `]`
+  inside character classes, unsupported-looking tokens inside regex comments,
+  and Ruby-compatible first-`)` regex comment termination.
 
 ### Slice 7: Divergence Removal And Codebase Cleanup
 

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -947,6 +947,16 @@ Definition of done:
 - The library rejects server-rejected regex features even if regexp2 can execute
   them.
 
+Current Slice 6 progress:
+
+- A pre-compile regex validator now rejects the explicit server-denied token
+  families from `Conditional::Regexp`: lookbehind, negative lookbehind, atomic
+  groups, possessive `?+`, `*+`, and `++` quantifiers, angle and single-quote
+  named captures, and regex conditionals.
+- Source-tagged regex validation tests cover those rejected constructs and guard
+  that escaped text and character class contents are not mistaken for regex
+  features.
+
 ### Slice 7: Divergence Removal And Codebase Cleanup
 
 Remove syntax, tests, examples, and package shape that conflict with exact

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -959,7 +959,8 @@ Current Slice 6 progress:
 - Review hardening now covers RE2-style `(?P<name>...)` named captures, POSIX
   classes followed by literal unsupported-looking tokens, leading literal `]`
   inside character classes, unsupported-looking tokens inside regex comments,
-  and Ruby-compatible first-`)` regex comment termination.
+  Ruby-compatible first-`)` regex comment termination, and bounded possessive
+  quantifiers such as `{1,3}+` and `{2,}+`.
 
 ### Slice 7: Divergence Removal And Codebase Cleanup
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -239,6 +239,10 @@ func (p *Parser) parseRegexp() ast.Expression {
 		p.errors = append(p.errors, err.Error())
 		return nil
 	}
+	if err := validateRegexp(p.curToken.Literal); err != nil {
+		p.errors = append(p.errors, err.Error())
+		return nil
+	}
 
 	r, err := regexp2.Compile(p.curToken.Literal, options)
 	if err != nil {
@@ -266,6 +270,71 @@ func regexpOptions(flags string) (regexp2.RegexOptions, error) {
 	}
 
 	return options, nil
+}
+
+func validateRegexp(pattern string) error {
+	escaped := false
+	inClass := false
+
+	for i := 0; i < len(pattern); i++ {
+		ch := pattern[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if inClass {
+			if ch == ']' {
+				inClass = false
+			}
+			continue
+		}
+		if ch == '[' {
+			inClass = true
+			continue
+		}
+
+		if ch == '(' && i+1 < len(pattern) && pattern[i+1] == '?' {
+			switch {
+			case hasRegexpPrefix(pattern, i, "(?<="):
+				return unsupportedRegexpFeature("lookbehind")
+			case hasRegexpPrefix(pattern, i, "(?<!"):
+				return unsupportedRegexpFeature("nlookbehind")
+			case hasRegexpPrefix(pattern, i, "(?>"):
+				return unsupportedRegexpFeature("atomic")
+			case hasRegexpPrefix(pattern, i, "(?<"):
+				return unsupportedRegexpFeature("named_ab")
+			case hasRegexpPrefix(pattern, i, "(?'"):
+				return unsupportedRegexpFeature("named_sq")
+			case hasRegexpPrefix(pattern, i, "(?("):
+				return unsupportedRegexpFeature("condition_open")
+			}
+		}
+
+		if i+1 < len(pattern) && pattern[i+1] == '+' {
+			switch ch {
+			case '?':
+				return unsupportedRegexpFeature("zero_or_one_possessive")
+			case '*':
+				return unsupportedRegexpFeature("zero_or_more_possessive")
+			case '+':
+				return unsupportedRegexpFeature("one_or_more_possessive")
+			}
+		}
+	}
+
+	return nil
+}
+
+func hasRegexpPrefix(pattern string, offset int, prefix string) bool {
+	return len(pattern)-offset >= len(prefix) && pattern[offset:offset+len(prefix)] == prefix
+}
+
+func unsupportedRegexpFeature(feature string) error {
+	return fmt.Errorf("unsupported regexp feature: %s", feature)
 }
 
 func (p *Parser) parsePrefixExpression() ast.Expression {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -275,11 +275,15 @@ func regexpOptions(flags string) (regexp2.RegexOptions, error) {
 func validateRegexp(pattern string) error {
 	escaped := false
 	inClass := false
+	classFirst := false
 
 	for i := 0; i < len(pattern); i++ {
 		ch := pattern[i]
 		if escaped {
 			escaped = false
+			if inClass {
+				classFirst = false
+			}
 			continue
 		}
 		if ch == '\\' {
@@ -290,16 +294,24 @@ func validateRegexp(pattern string) error {
 			if ch == '[' && i+1 < len(pattern) && isPOSIXClassMarker(pattern[i+1]) {
 				if end := regexpClassSetEnd(pattern, i); end != -1 {
 					i = end
+					classFirst = false
 				}
 				continue
 			}
 			if ch == ']' {
+				if classFirst {
+					classFirst = false
+					continue
+				}
 				inClass = false
+				continue
 			}
+			classFirst = false
 			continue
 		}
 		if ch == '[' {
 			inClass = true
+			classFirst = true
 			continue
 		}
 
@@ -320,6 +332,8 @@ func validateRegexp(pattern string) error {
 			case hasRegexpPrefix(pattern, i, "(?>"):
 				return unsupportedRegexpFeature("atomic")
 			case hasRegexpPrefix(pattern, i, "(?<"):
+				return unsupportedRegexpFeature("named_ab")
+			case hasRegexpPrefix(pattern, i, "(?P<"):
 				return unsupportedRegexpFeature("named_ab")
 			case hasRegexpPrefix(pattern, i, "(?'"):
 				return unsupportedRegexpFeature("named_sq")
@@ -361,16 +375,8 @@ func regexpClassSetEnd(pattern string, start int) int {
 }
 
 func regexpCommentEnd(pattern string, start int) int {
-	escaped := false
 	for i := start; i < len(pattern); i++ {
-		if escaped {
-			escaped = false
-			continue
-		}
-		switch pattern[i] {
-		case '\\':
-			escaped = true
-		case ')':
+		if pattern[i] == ')' {
 			return i
 		}
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -350,6 +350,10 @@ func validateRegexp(pattern string) error {
 				return unsupportedRegexpFeature("zero_or_more_possessive")
 			case '+':
 				return unsupportedRegexpFeature("one_or_more_possessive")
+			case '}':
+				if isBoundedRegexpQuantifierEnd(pattern, i) {
+					return unsupportedRegexpFeature("bounded_possessive")
+				}
 			}
 		}
 	}
@@ -381,6 +385,50 @@ func regexpCommentEnd(pattern string, start int) int {
 		}
 	}
 	return -1
+}
+
+func isBoundedRegexpQuantifierEnd(pattern string, close int) bool {
+	for open := close - 1; open >= 0; open-- {
+		if pattern[open] != '{' {
+			continue
+		}
+		if isEscapedRegexpByte(pattern, open) {
+			return false
+		}
+		return isRegexpQuantifierBounds(pattern[open+1 : close])
+	}
+	return false
+}
+
+func isEscapedRegexpByte(pattern string, offset int) bool {
+	backslashes := 0
+	for i := offset - 1; i >= 0 && pattern[i] == '\\'; i-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+func isRegexpQuantifierBounds(bounds string) bool {
+	if bounds == "" {
+		return false
+	}
+
+	digitsBeforeComma := 0
+	seenComma := false
+	for i := 0; i < len(bounds); i++ {
+		ch := bounds[i]
+		switch {
+		case ch >= '0' && ch <= '9':
+			if !seenComma {
+				digitsBeforeComma++
+			}
+		case ch == ',' && !seenComma:
+			seenComma = true
+		default:
+			return false
+		}
+	}
+	return digitsBeforeComma != 0
 }
 
 func hasRegexpPrefix(pattern string, offset int, prefix string) bool {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -287,6 +287,12 @@ func validateRegexp(pattern string) error {
 			continue
 		}
 		if inClass {
+			if ch == '[' && i+1 < len(pattern) && isPOSIXClassMarker(pattern[i+1]) {
+				if end := regexpClassSetEnd(pattern, i); end != -1 {
+					i = end
+				}
+				continue
+			}
 			if ch == ']' {
 				inClass = false
 			}
@@ -298,6 +304,14 @@ func validateRegexp(pattern string) error {
 		}
 
 		if ch == '(' && i+1 < len(pattern) && pattern[i+1] == '?' {
+			if hasRegexpPrefix(pattern, i, "(?#") {
+				end := regexpCommentEnd(pattern, i+3)
+				if end == -1 {
+					return nil
+				}
+				i = end
+				continue
+			}
 			switch {
 			case hasRegexpPrefix(pattern, i, "(?<="):
 				return unsupportedRegexpFeature("lookbehind")
@@ -327,6 +341,40 @@ func validateRegexp(pattern string) error {
 	}
 
 	return nil
+}
+
+func isPOSIXClassMarker(ch byte) bool {
+	return ch == ':' || ch == '.' || ch == '='
+}
+
+func regexpClassSetEnd(pattern string, start int) int {
+	if start+1 >= len(pattern) {
+		return -1
+	}
+	marker := pattern[start+1]
+	for i := start + 2; i+1 < len(pattern); i++ {
+		if pattern[i] == marker && pattern[i+1] == ']' {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func regexpCommentEnd(pattern string, start int) int {
+	escaped := false
+	for i := start; i < len(pattern); i++ {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch pattern[i] {
+		case '\\':
+			escaped = true
+		case ')':
+			return i
+		}
+	}
+	return -1
 }
 
 func hasRegexpPrefix(pattern string, offset int, prefix string) bool {

--- a/regex_test.go
+++ b/regex_test.go
@@ -144,6 +144,12 @@ func TestConditionalRegexValidation(t *testing.T) {
 			wantError:  ErrorKindParse,
 		},
 		{
+			name:       "python named capture fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"group" =~ /(?P<name>group)/`,
+			wantError:  ErrorKindParse,
+		},
+		{
 			name:       "single quote named capture fails during parsing",
 			source:     upstreamConditionalRegexpModel,
 			expression: `"group" =~ /(?'name'group)/`,
@@ -153,6 +159,12 @@ func TestConditionalRegexValidation(t *testing.T) {
 			name:       "conditional regexp fails during parsing",
 			source:     upstreamConditionalRegexpModel,
 			expression: `"a" =~ /(?(1)a|b)/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "escaped closing parenthesis ends regexp comment",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"ab" =~ /a(?#\)(?<name>b)/`,
 			wantError:  ErrorKindParse,
 		},
 		{
@@ -171,9 +183,14 @@ func TestConditionalRegexValidation(t *testing.T) {
 			expression: `"?" =~ /[[:digit:](?<=]/`,
 		},
 		{
+			name:       "leading closing bracket stays literal inside character class",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"]" =~ /[](?<=]/`,
+		},
+		{
 			name:       "regexp comment contents are ignored by feature validator",
 			source:     upstreamConditionalRegexpModel,
-			expression: `"ab" =~ /a(?# (?<= literal)b/`,
+			expression: `"ab" =~ /a(?# (?<= literal )b/`,
 		},
 	}
 

--- a/regex_test.go
+++ b/regex_test.go
@@ -101,6 +101,70 @@ func TestConditionalRegexValidation(t *testing.T) {
 			expression: `"main" =~ /main`,
 			wantError:  ErrorKindParse,
 		},
+		{
+			name:       "lookbehind fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"ab" =~ /(?<=a)b/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "negative lookbehind fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"cb" =~ /(?<!a)b/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "atomic group fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aa" =~ /(?>a*)a/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "zero or one possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"a" =~ /a?+/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "zero or more possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aaa" =~ /a*+/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "one or more possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aaa" =~ /a++/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "angle named capture fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"group" =~ /(?<name>group)/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "single quote named capture fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"group" =~ /(?'name'group)/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "conditional regexp fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"a" =~ /(?(1)a|b)/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "escaped unsupported tokens remain literals",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"(?<=a)" =~ /\(\?<=a\)/`,
+		},
+		{
+			name:       "character class unsupported tokens remain literals",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"?" =~ /[(?<=]/`,
+		},
 	}
 
 	runValidateCases(t, tests)

--- a/regex_test.go
+++ b/regex_test.go
@@ -165,6 +165,16 @@ func TestConditionalRegexValidation(t *testing.T) {
 			source:     upstreamConditionalRegexpModel,
 			expression: `"?" =~ /[(?<=]/`,
 		},
+		{
+			name:       "posix character class keeps outer class open",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"?" =~ /[[:digit:](?<=]/`,
+		},
+		{
+			name:       "regexp comment contents are ignored by feature validator",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"ab" =~ /a(?# (?<= literal)b/`,
+		},
 	}
 
 	runValidateCases(t, tests)

--- a/regex_test.go
+++ b/regex_test.go
@@ -138,6 +138,24 @@ func TestConditionalRegexValidation(t *testing.T) {
 			wantError:  ErrorKindParse,
 		},
 		{
+			name:       "bounded possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aaa" =~ /a{1,3}+/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "exact bounded possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aaa" =~ /a{3}+/`,
+			wantError:  ErrorKindParse,
+		},
+		{
+			name:       "open ended bounded possessive quantifier fails during parsing",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"aaa" =~ /a{2,}+/`,
+			wantError:  ErrorKindParse,
+		},
+		{
 			name:       "angle named capture fails during parsing",
 			source:     upstreamConditionalRegexpModel,
 			expression: `"group" =~ /(?<name>group)/`,
@@ -171,6 +189,16 @@ func TestConditionalRegexValidation(t *testing.T) {
 			name:       "escaped unsupported tokens remain literals",
 			source:     upstreamConditionalRegexpModel,
 			expression: `"(?<=a)" =~ /\(\?<=a\)/`,
+		},
+		{
+			name:       "escaped bounded quantifier text remains literal",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"{1,3}+" =~ /\{1,3\}\+/`,
+		},
+		{
+			name:       "bare closing brace remains literal",
+			source:     upstreamConditionalRegexpModel,
+			expression: `"}}}" =~ /}+/`,
 		},
 		{
 			name:       "character class unsupported tokens remain literals",


### PR DESCRIPTION
Buildkite uses Ruby regexes, but the server explicitly rejects a set of regex features through `Conditional::Regexp` before evaluation. Since this library now uses regexp2, those constructs could compile locally even though the server would fail closed.

This adds a pre-compile validator for the server-denied token families:

- lookbehind and negative lookbehind
- atomic groups
- possessive `?+`, `*+`, and `++` quantifiers
- angle and single-quote named captures
- regex conditionals

The table-driven regex suite now covers each rejected family and guards escaped text and character-class contents so the lexical validator does not reject literal text. The parity plan records this as the first Slice 6 regex validator pass.