### PR TITLE
fix: Remove @> compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Buildkite Conditional Evaluator
 
-A small c-like language for evaluating boolean conditions, used in Buildkite's pipeline.yml format and for filtering whether webhooks are accepted.
+A small Go library for validating and evaluating Buildkite conditional
+expressions.
 
 ## What's supported?
 
@@ -10,11 +11,11 @@ A small c-like language for evaluating boolean conditions, used in Buildkite's p
 * Strings `'foobar' or "foobar"`
 * Booleans and nulls `true false null`
 * Parenthesis to control order of evaluation `( )`
-* Object dereferencing `foo.bar`
+* Buildkite identifiers such as `build.branch`
 * Regular expressions `/^v1\.0/`
-* Function calls `foo("bar")`
+* Function calls such as `env("FOO")` and `build.env("FOO")`
 * Prefixes: `!`
-* Arrays: `["foo","bar"] includes "foo"` (`@>` is also supported for compatibility)
+* Arrays: `["foo","bar"] includes "foo"`
 
 ### Syntax Examples
 
@@ -30,16 +31,15 @@ build.tag != "v1.0.0"
 "blah" == 'blah'
 
 // function calls
-env('FOO') == "BAR"
-env('FOO') == obj.bar
-env(env('BAR')) == "FOO"
+env("FOO") == "BAR"
+build.env("BUILDKITE_BRANCH") == build.branch
 
 // regular expression matches
 build.tag =~ /^v/
 build.message !~ /\[skip tests\]/i
 
 // complex expressions
-((build.tag =~ ^v) || (meta-data("foo") == "bar"))
+((build.tag =~ /^v/) || (build.branch == "main"))
 
 // array operations
 ["master","staging"] includes build.branch
@@ -58,35 +58,33 @@ package main
 import (
 	"log"
 
-	"github.com/buildkite/conditional/evaluator"
-	"github.com/buildkite/conditional/lexer"
-	"github.com/buildkite/conditional/object"
-	"github.com/buildkite/conditional/parser"
+	"github.com/buildkite/conditional"
 )
 
 func main() {
-	l := lexer.New(`build.message =~ /^llamas rock/`)
-	p := parser.New(l)
-	expr := p.Parse()
+	message := "llamas rock, and so do alpacas"
 
-	if errs := p.Errors(); len(errs) > 0 {
-		log.Fatal(errs)
-	}
-
-	obj := evaluator.Eval(expr, object.Struct{
-		"build": object.Struct{
-			"message": &object.String{"llamas rock, and so do alpacas"},
+	ok, err := conditional.Evaluate(`build.message =~ /^llamas rock/`, conditional.Context{
+		EntryPoint: conditional.EntryPointBuildCondition,
+		Build: conditional.Build{
+			Message: &message,
 		},
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	log.Printf("Result: %#v", obj)
+	log.Printf("Result: %#v", ok)
 }
 ```
 
 ## Design
 
-Largely derived from [Writing an Interpreter in Go](https://interpreterbook.com):
+The root package is the public Buildkite API:
 
-* `lexer.Lexer` takes a string of input and turns it into a stream of `token.Token`
-* `parser.Parser` takes a Lexer and parses tokens into an `ast.Expression`
-* `evaluator.Evaluator` which takes a `ast.Expression` and evaluates it, with a `object.Map` for variables in scope. An `*object.Object` is returned.
+* `conditional.Validate` checks an expression for a Buildkite context.
+* `conditional.Evaluate` evaluates an expression and returns a boolean result.
+* `conditional.Context` defines the Buildkite entry point and available values.
+
+The lexer, parser, and evaluator packages are implementation details derived
+from [Writing an Interpreter in Go](https://interpreterbook.com).

--- a/conditional.go
+++ b/conditional.go
@@ -100,9 +100,6 @@ func validateExpression(expr ast.Expression, ctx Context) error {
 	if err := validateEnvCalls(expr); err != nil {
 		return err
 	}
-	if err := validateOperators(expr); err != nil {
-		return err
-	}
 	return typeCheckExpression(expr, ctx)
 }
 
@@ -169,43 +166,6 @@ func validateEnvCalls(expr ast.Expression) error {
 	case *ast.ArrayLiteral:
 		for _, element := range expr.Elements {
 			if err := validateEnvCalls(element); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func validateOperators(expr ast.Expression) error {
-	switch expr := expr.(type) {
-	case *ast.PrefixExpression:
-		return validateOperators(expr.Right)
-	case *ast.ConditionalExpression:
-		if err := validateOperators(expr.Condition); err != nil {
-			return err
-		}
-		if err := validateOperators(expr.Consequence); err != nil {
-			return err
-		}
-		return validateOperators(expr.Alternative)
-	case *ast.InfixExpression:
-		if expr.Operator == "@>" {
-			return &Error{Kind: ErrorKindValidation, Message: "@> is not Buildkite conditional syntax"}
-		}
-		if err := validateOperators(expr.Left); err != nil {
-			return err
-		}
-		return validateOperators(expr.Right)
-	case *ast.CallExpression:
-		for _, arg := range expr.Arguments {
-			if err := validateOperators(arg); err != nil {
-				return err
-			}
-		}
-	case *ast.ArrayLiteral:
-		for _, element := range expr.Elements {
-			if err := validateOperators(element); err != nil {
 				return err
 			}
 		}

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -489,7 +489,7 @@ from this plan.
 | Context restrictions | Root entrypoints now model build conditions, build conditions with a step, build notifications, and step notifications. `step.*` fails validation unless the entrypoint supplies a step, and notification entrypoints convert parse, validation, and evaluation errors to `false`. | Finish auditing entrypoint-specific docs/server differences, especially variables documented as notification-only but exposed by `Build::Condition.context`. |
 | Final result | Root `Validate`/`Evaluate` now type-check for a boolean final result; lower-level `Eval` still returns any `object.Object` during transition. | Move implementation packages under `internal/` and keep root `(bool, error)` as the supported Buildkite surface. |
 | Regex syntax | regexp2 accepts some features the server rejects. | Keep regexp2 only with a server-compatible validator for flags and unsupported constructs. |
-| Divergent operators | `@>` no longer tokenizes as a Buildkite parser operator. Some lower-level compatibility constants may remain until cleanup. | Remove remaining dead `@>` constants or generic-language artifacts in the cleanup slice. |
+| Divergent operators | `@>` no longer tokenizes as a Buildkite parser operator, and the dead token/parser/root-validation compatibility artifacts have been removed. | Keep parser/root divergence tests so local-only syntax stays rejected. |
 | Type mismatch semantics | Core equality, regex matching, `includes`, `!`, logical, ternary, enum, null, array comparison, and concrete Buildkite function cases now use server-derived type-checking behavior. | Finish exact error category coverage and the remaining context-driven function cases. |
 | Conformance | Root package tests are now split into source-tagged table-driven files for syntax, evaluation, regex, context, and root API error behavior. The tables seed docs and upstream spec coverage but do not yet port every blocked upstream group. | Expand the tables in each implementation slice until every manifest group is `ported`, `superseded`, or `intentionally_excluded` before claiming parity. |
 
@@ -980,6 +980,17 @@ Definition of done:
   availability, supported syntax, and fail-closed behavior.
 - Package boundaries are reviewed for cohesion, exported identifiers, comments,
   and unnecessary interfaces.
+
+Current Slice 7 progress:
+
+- Removed the dead `@>` token, parser precedence entry, and root validation
+  fallback. Lexer, parser, and root API tests still cover parse-time rejection
+  for `@>`.
+- README examples now use server-compatible Buildkite conditionals and the root
+  `conditional.Validate`/`conditional.Evaluate` API instead of lower-level
+  lexer/parser/evaluator wiring.
+- Removed README examples that advertised `@>` compatibility, unavailable
+  `meta-data("foo")`, and generic object/function syntax.
 
 ### Slice 8: Optional Server Oracle
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -165,7 +165,7 @@ func TestLexingArrays(t *testing.T) {
 	})
 }
 
-func TestLexingRejectsNonServerContainsOperator(t *testing.T) {
+func TestLexingRejectsAtGreaterOperator(t *testing.T) {
 	expectTokens(t, `["llamas", "alpacas"] @> "alpacas"`, []tokenExpectation{
 		{token.LBRACKET, "["},
 		{token.STRING, "llamas"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,7 +31,6 @@ var precedences = map[token.TokenType]int{
 	token.NOT_EQ:    EQUALS,
 	token.RE_EQ:     EQUALS,
 	token.RE_NOT_EQ: EQUALS,
-	token.CONTAINS:  EQUALS,
 	token.INCLUDES:  EQUALS,
 	token.AND:       AND,
 	token.OR:        OR,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -470,7 +470,7 @@ func TestParsingArrayLiterals(t *testing.T) {
 	testIdentifierOrString(t, array.Elements[1], "alpacas")
 }
 
-func TestParsingContainsOperators(t *testing.T) {
+func TestParsingIncludesOperator(t *testing.T) {
 	tests := []struct {
 		input    string
 		operator string
@@ -490,12 +490,12 @@ func TestParsingContainsOperators(t *testing.T) {
 		}
 
 		if iexpr.Operator != tt.operator {
-			t.Fatalf("exp doesn't have expected contains operator. want=%s got=%s", tt.operator, iexpr.Operator)
+			t.Fatalf("exp doesn't have expected includes operator. want=%s got=%s", tt.operator, iexpr.Operator)
 		}
 	}
 }
 
-func TestParserRejectsNonServerContainsOperator(t *testing.T) {
+func TestParserRejectsAtGreaterOperator(t *testing.T) {
 	l := lexer.New(`["llamas", "alpacas"] @> "llamas"`)
 	p := New(l)
 	p.Parse()

--- a/syntax_test.go
+++ b/syntax_test.go
@@ -108,7 +108,7 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 			wantError:  ErrorKindParse,
 		},
 		{
-			name:       "parser rejects local-only contains operator",
+			name:       "parser rejects local-only at greater operator",
 			source:     upstreamParserSpec,
 			expression: `["main"] @> build.branch`,
 			ctx: Context{
@@ -227,7 +227,7 @@ func TestConditionalSyntaxErrors(t *testing.T) {
 func TestConditionalSyntaxEvaluationErrors(t *testing.T) {
 	tests := []evaluateCase{
 		{
-			name:       "evaluation rejects local-only contains operator at parse time",
+			name:       "evaluation rejects local-only at greater operator at parse time",
 			source:     upstreamParserSpec,
 			expression: `["main"] @> build.branch`,
 			ctx: Context{

--- a/token/token.go
+++ b/token/token.go
@@ -21,7 +21,6 @@ const (
 	NOT_EQ    = "!="
 	RE_EQ     = "=~"
 	RE_NOT_EQ = "!~"
-	CONTAINS  = "@>"
 	INCLUDES  = "includes"
 
 	// Boolean Operators


### PR DESCRIPTION
Buildkite server conditionals do not support `@>`, but this repo still carried compatibility-era artifacts and the README still advertised it as supported. That made the public surface look broader than the server language this library is meant to match.

This removes the dead `@>` token, parser precedence entry, and root validation fallback. Lexer, parser, and root API tests still assert that `@>` fails at parse time, so local-only syntax remains rejected.

The README now uses server-compatible Buildkite conditional examples and shows the root `conditional.Evaluate` API instead of wiring lexer/parser/evaluator internals directly.