### PR TITLE
refactor: Remove nested dotted lookup

### DIFF
--- a/conditional.go
+++ b/conditional.go
@@ -220,18 +220,11 @@ func buildScope(ctx Context) evaluationScope {
 	env := mergedEnv(ctx)
 
 	scope := object.Struct{
-		"env":          envFunction(env),
-		"build.env":    nullableEnvFunction(env),
-		"build":        buildObject(ctx),
-		"pipeline":     pipelineObject(ctx.Pipeline),
-		"organization": organizationObject(ctx.Organization),
+		"env":       envFunction(env),
+		"build.env": nullableEnvFunction(env),
 	}
 	for key, value := range flatAssignments(ctx) {
 		scope[key] = value
-	}
-
-	if stepAllowed(ctx.EntryPoint) {
-		scope["step"] = stepObject(ctx.Step)
 	}
 
 	return evaluationScope{Struct: scope, env: env}
@@ -329,125 +322,24 @@ func flatAssignments(ctx Context) object.Struct {
 	}
 
 	if stepAllowed(ctx.EntryPoint) {
-		step := stepObject(ctx.Step)
-		assignments["step.id"] = step["id"]
-		assignments["step.key"] = step["key"]
-		assignments["step.type"] = step["type"]
-		assignments["step.label"] = step["label"]
-		assignments["step.state"] = step["state"]
-		assignments["step.outcome"] = step["outcome"]
+		if ctx.Step == nil {
+			assignments["step.id"] = &object.Null{}
+			assignments["step.key"] = &object.Null{}
+			assignments["step.type"] = &object.Null{}
+			assignments["step.label"] = &object.Null{}
+			assignments["step.state"] = &object.Null{}
+			assignments["step.outcome"] = &object.Null{}
+		} else {
+			assignments["step.id"] = stringValue(ctx.Step.ID)
+			assignments["step.key"] = stringValue(ctx.Step.Key)
+			assignments["step.type"] = stringValue(ctx.Step.Type)
+			assignments["step.label"] = stringValue(ctx.Step.Label)
+			assignments["step.state"] = stringValue(ctx.Step.State)
+			assignments["step.outcome"] = stringValue(ctx.Step.Outcome)
+		}
 	}
 
 	return assignments
-}
-
-func buildObject(ctx Context) object.Struct {
-	build := ctx.Build
-	return object.Struct{
-		"id":            stringValue(build.ID),
-		"state":         stringValue(build.State),
-		"fixed":         boolValue(build.Fixed),
-		"blocked_state": stringValue(build.BlockedState),
-		"source":        stringValue(build.Source),
-		"source_event":  stringValue(sourceEvent(ctx)),
-		"source_action": stringValue(sourceAction(ctx)),
-		"branch":        stringValue(build.Branch),
-		"tag":           presenceStringValue(build.Tag),
-		"message":       presenceStringValue(build.Message),
-		"commit":        stringValue(build.Commit),
-		"number":        intValue(build.Number),
-		"creator":       actorObject(build.Creator, actorOptions{includeVerified: true}),
-		"author":        actorObject(build.Author, actorOptions{presenceNameEmail: true}),
-		"scm": object.Struct{
-			"author": object.Struct{
-				"name":  stringValue(build.SCM.AuthorName),
-				"email": stringValue(build.SCM.AuthorEmail),
-			},
-			"committer": object.Struct{
-				"name":  stringValue(build.SCM.CommitterName),
-				"email": stringValue(build.SCM.CommitterEmail),
-			},
-		},
-		"pull_request": object.Struct{
-			"id":          stringValue(build.PullRequest.ID),
-			"base_branch": stringValue(build.PullRequest.BaseBranch),
-			"draft":       boolValue(build.PullRequest.Draft),
-			"label":       stringValue(pullRequestLabel(ctx)),
-			"labels":      stringArrayValue(build.PullRequest.Labels),
-			"repository": object.Struct{
-				"fork": boolValue(build.PullRequest.RepositoryFork),
-			},
-		},
-		"merge_queue": object.Struct{
-			"base_branch": stringValue(build.MergeQueue.BaseBranch),
-			"base_commit": stringValue(build.MergeQueue.BaseCommit),
-		},
-	}
-}
-
-type actorOptions struct {
-	includeVerified   bool
-	presenceNameEmail bool
-}
-
-func actorObject(actor Actor, options actorOptions) object.Struct {
-	name := stringValue(actor.Name)
-	email := stringValue(actor.Email)
-	if options.presenceNameEmail {
-		name = presenceStringValue(actor.Name)
-		email = presenceStringValue(actor.Email)
-	}
-
-	out := object.Struct{
-		"id":    stringValue(actor.ID),
-		"name":  name,
-		"email": email,
-		"teams": stringArrayValue(actor.Teams),
-	}
-	if options.includeVerified {
-		out["verified"] = boolValue(actor.Verified)
-	}
-	return out
-}
-
-func pipelineObject(pipeline Pipeline) object.Struct {
-	return object.Struct{
-		"id":                         stringValue(pipeline.ID),
-		"slug":                       stringValue(pipeline.Slug),
-		"default_branch":             presenceStringValue(pipeline.DefaultBranch),
-		"repository":                 presenceStringValue(pipeline.Repository),
-		"started_passing":            boolValue(pipeline.StartedPassing),
-		"started_failing":            boolValue(pipeline.StartedFailing),
-		"next_finished_build_exists": boolValue(pipeline.NextFinishedBuildExists),
-	}
-}
-
-func organizationObject(organization Organization) object.Struct {
-	return object.Struct{
-		"id":   stringValue(organization.ID),
-		"slug": stringValue(organization.Slug),
-	}
-}
-
-func stepObject(step *Step) object.Struct {
-	if step == nil {
-		return object.Struct{
-			"id":      &object.Null{},
-			"key":     &object.Null{},
-			"type":    &object.Null{},
-			"label":   &object.Null{},
-			"state":   &object.Null{},
-			"outcome": &object.Null{},
-		}
-	}
-	return object.Struct{
-		"id":      stringValue(step.ID),
-		"key":     stringValue(step.Key),
-		"type":    stringValue(step.Type),
-		"label":   stringValue(step.Label),
-		"state":   stringValue(step.State),
-		"outcome": stringValue(step.Outcome),
-	}
 }
 
 func sourceEvent(ctx Context) *string {

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -480,7 +480,7 @@ from this plan.
 
 | Area | Current Behavior | Required Direction |
 | --- | --- | --- |
-| Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables, and implementation packages are under `internal/`. | Finish auditing any remaining nested object lookup assumptions behind the root API. |
+| Dotted names | Parser and evaluator internals now use flat dotted identifiers for server variables; nested dotted lookup fallback has been removed, and implementation packages are under `internal/`. | Keep flat dotted identifier/function conformance coverage as new server variables are added. |
 | `build.env()` | `build.env("NAME")` parses as a flat function identifier, type-checks with the server's string return token type, evaluates to `null` for absent variables, and fails closed for blank or unsupported dynamic `BUILDKITE_*` names. | Expand validator and conformance coverage for the full server env matrix in Slice 5. |
 | Ternary syntax | Ternaries parse with server precedence, evaluate lazily, use Ruby truthiness for nil runtime conditions, and type-check branch compatibility without local nullable-union narrowing. | Expand conformance coverage for every upstream ternary type-checker case before marking Slice 4 complete. |
 | Shell substitution | Shell expansion operands, double-quoted interpolation, server string escapes, and quoted fallback strings evaluate for the upstream set/unset/empty/default/alternate/required/substring matrix and representative fallback grammar cases. | Run a final upstream parser/evaluator audit before marking every shell substitution group accounted for. |
@@ -994,6 +994,9 @@ Current Slice 7 progress:
 - Moved implementation packages under `internal/`, including `ast`, `evaluator`,
   `lexer`, `object`, `parser`, `repl`, and `token`, so the root package is the
   supported public Buildkite API.
+- Removed nested dotted lookup fallback from the internal evaluator and root
+  scope builder. Buildkite names now resolve through flat assignment keys such
+  as `build.message` and `build.env`.
 
 ### Slice 8: Optional Server Oracle
 

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -2,7 +2,6 @@ package evaluator
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/buildkite/conditional/internal/ast"
 	"github.com/buildkite/conditional/internal/object"
@@ -358,30 +357,6 @@ func resolveScopedName(name string, scope Scope) (object.Object, bool) {
 	if val, ok := scope.Get(name); ok {
 		return val, true
 	}
-
-	if !strings.Contains(name, ".") {
-		return nil, false
-	}
-
-	var current Scope = scope
-	parts := strings.Split(name, ".")
-	for i, part := range parts {
-		val, ok := current.Get(part)
-		if !ok {
-			return nil, false
-		}
-
-		if i == len(parts)-1 {
-			return val, true
-		}
-
-		next, ok := val.(Scope)
-		if !ok {
-			return nil, false
-		}
-		current = next
-	}
-
 	return nil, false
 }
 

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -166,7 +166,7 @@ func TestFlatDottedIdentifier(t *testing.T) {
 	}
 }
 
-func TestNestedDottedIdentifierFallback(t *testing.T) {
+func TestNestedDottedIdentifierIsNotResolved(t *testing.T) {
 	scope := object.Struct{
 		"build": object.Struct{
 			"message": &object.String{Value: "deploy"},
@@ -174,10 +174,16 @@ func TestNestedDottedIdentifierFallback(t *testing.T) {
 	}
 
 	evaluated := testEvalWithScope(`build.message == "deploy"`, scope)
-	testBooleanObject(t, evaluated, true)
+	result, ok := evaluated.(*object.Error)
+	if !ok {
+		t.Fatalf("result is not an error. got=%T (%+v)", evaluated, evaluated)
+	}
+	if result.Message != `identifier not found: build.message` {
+		t.Fatalf("bad error message: %v", result.Message)
+	}
 }
 
-func TestFlatDottedIdentifierTakesPrecedence(t *testing.T) {
+func TestFlatDottedIdentifierIgnoresNestedStructs(t *testing.T) {
 	scope := object.Struct{
 		"build.message": &object.String{Value: "flat"},
 		"build": object.Struct{
@@ -202,7 +208,7 @@ func TestFlatDottedIdentifierFailsOnMissingAssignment(t *testing.T) {
 	}
 }
 
-func TestNestedDottedFunctionFallback(t *testing.T) {
+func TestNestedDottedFunctionIsNotResolved(t *testing.T) {
 	scope := object.Struct{
 		"build": object.Struct{
 			"env": object.Function(func(args []object.Object) object.Object {
@@ -212,10 +218,16 @@ func TestNestedDottedFunctionFallback(t *testing.T) {
 	}
 
 	evaluated := testEvalWithScope(`build.env("FOO") == "from-nested"`, scope)
-	testBooleanObject(t, evaluated, true)
+	result, ok := evaluated.(*object.Error)
+	if !ok {
+		t.Fatalf("result is not an error. got=%T (%+v)", evaluated, evaluated)
+	}
+	if result.Message != `function not defined: build.env` {
+		t.Fatalf("bad error message: %v", result.Message)
+	}
 }
 
-func TestContainsOperator(t *testing.T) {
+func TestIncludesOperator(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected bool
@@ -230,7 +242,7 @@ func TestContainsOperator(t *testing.T) {
 	}
 }
 
-func TestContainsOperatorWithScopeArray(t *testing.T) {
+func TestIncludesOperatorWithScopeArray(t *testing.T) {
 	scope := object.Struct{
 		"build.creator.teams": &object.Array{Elements: []object.Object{
 			&object.String{Value: "deploy"},


### PR DESCRIPTION
Buildkite conditionals treat dotted names as flat assignment and function names, but the internal evaluator still had a generic nested-map fallback. That fallback made lower-level behavior broader than the server grammar and forced the root scope to keep duplicate nested `build`, `pipeline`, `organization`, and `step` objects.

This removes nested dotted identifier and function fallback from the evaluator. The root scope now publishes only flat Buildkite assignment keys such as `build.message`, `pipeline.slug`, `step.id`, and the flat `build.env` function.

The evaluator tests now prove nested structs are ignored and flat dotted assignments are the only dotted lookup path.