### PR TITLE
docs: Describe root API behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,20 @@ Set `Context.EntryPoint` to the Buildkite location where the conditional runs:
 * `EntryPointBuildCondition` evaluates build conditionals without `step.*`.
 * `EntryPointBuildConditionWithStep` evaluates build conditionals where step
   variables are available.
-* `EntryPointBuildNotification` evaluates build notification conditionals and
-  converts parse, validation, and evaluation errors to `false`.
+* `EntryPointBuildNotification` evaluates build notification conditionals.
+  `Evaluate` converts parse, validation, and evaluation errors to `false`.
 * `EntryPointStepNotification` evaluates step notification conditionals with
-  `step.*` variables and converts parse, validation, and evaluation errors to
-  `false`.
+  `step.*` variables. `Evaluate` converts parse, validation, and evaluation
+  errors to `false`.
 
 ## Variables
 
 The root API builds flat Buildkite assignments from `Context`:
 
 * `build.*` values come from `Context.Build`.
-* `pipeline.*` values come from `Context.Pipeline`.
+* `pipeline.*` values come from documented `Context.Pipeline` fields:
+  `id`, `slug`, `default_branch`, `repository`, `started_passing`,
+  `started_failing`, and `next_finished_build_exists`.
 * `organization.*` values come from `Context.Organization`.
 * `step.*` values come from `Context.Step` only for step-aware entrypoints.
 * `env("NAME")` reads the merged build and project environment, returning an
@@ -80,6 +82,10 @@ Missing documented nullable values evaluate as `null`. Unknown variables,
 unknown functions, unsupported `BUILDKITE_*` env names, invalid regular
 expressions, unsupported regular expression features, type mismatches, and
 non-boolean final results fail closed.
+
+`Validate` always reports parse and validation errors. `Evaluate` reports errors
+for build condition entrypoints, while notification entrypoints return `false`
+for parse, validation, and evaluation errors.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,37 @@ run. In pipeline YAML, escape `$` anchors to avoid interpolation; by the time th
 conditional is parsed, an end anchor should be a raw `$`. Regex escapes such as
 `\$` are preserved as literal-dollar matches.
 
+## Entrypoints
+
+Set `Context.EntryPoint` to the Buildkite location where the conditional runs:
+
+* `EntryPointBuildCondition` evaluates build conditionals without `step.*`.
+* `EntryPointBuildConditionWithStep` evaluates build conditionals where step
+  variables are available.
+* `EntryPointBuildNotification` evaluates build notification conditionals and
+  converts parse, validation, and evaluation errors to `false`.
+* `EntryPointStepNotification` evaluates step notification conditionals with
+  `step.*` variables and converts parse, validation, and evaluation errors to
+  `false`.
+
+## Variables
+
+The root API builds flat Buildkite assignments from `Context`:
+
+* `build.*` values come from `Context.Build`.
+* `pipeline.*` values come from `Context.Pipeline`.
+* `organization.*` values come from `Context.Organization`.
+* `step.*` values come from `Context.Step` only for step-aware entrypoints.
+* `env("NAME")` reads the merged build and project environment, returning an
+  empty string when the name is absent.
+* `build.env("NAME")` reads the same merged environment, returning `null` when
+  the name is absent.
+
+Missing documented nullable values evaluate as `null`. Unknown variables,
+unknown functions, unsupported `BUILDKITE_*` env names, invalid regular
+expressions, unsupported regular expression features, type mismatches, and
+non-boolean final results fail closed.
+
 ## Usage
 
 ```go

--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,8 @@
 // set Context.EntryPoint to the place where the conditional runs, then call
 // Validate or Evaluate.
 //
-// Build condition entrypoints return validation and evaluation errors to the
-// caller. Notification entrypoints model Buildkite notification delivery and
-// convert parse, validation, and evaluation errors to false.
+// Validate always returns parse and validation errors. Evaluate returns errors
+// for build condition entrypoints. Notification entrypoints model Buildkite
+// notification delivery, so Evaluate converts parse, validation, and evaluation
+// errors to false for those entrypoints.
 package conditional

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,11 @@
-// Package conditional evaluates Buildkite conditional expressions.
+// Package conditional validates and evaluates Buildkite conditional
+// expressions.
 //
-// The public API models Buildkite's server-side conditional entrypoints while
-// the parser and evaluator internals continue to evolve toward exact server
-// parity.
+// The public API is the root package. Use Context to provide Buildkite values,
+// set Context.EntryPoint to the place where the conditional runs, then call
+// Validate or Evaluate.
+//
+// Build condition entrypoints return validation and evaluation errors to the
+// caller. Notification entrypoints model Buildkite notification delivery and
+// convert parse, validation, and evaluation errors to false.
 package conditional

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -997,6 +997,8 @@ Current Slice 7 progress:
 - Removed nested dotted lookup fallback from the internal evaluator and root
   scope builder. Buildkite names now resolve through flat assignment keys such
   as `build.message` and `build.env`.
+- Public README and package docs now describe the root API, entrypoints,
+  variable roots, nullable missing values, and fail-closed behavior.
 
 ### Slice 8: Optional Server Oracle
 


### PR DESCRIPTION
The root package is now the supported Buildkite API, but the public docs only showed syntax and a short usage example. Callers still had to infer which entrypoints to use, which variable roots are available, and how fail-closed behavior works.

This adds README sections for entrypoints, flat variable roots, `env()` versus `build.env()` missing-value behavior, and fail-closed outcomes. The package comment now carries the same root API framing for generated Go docs.

The parity plan records this as the public-documentation part of Slice 7.