### PR TITLE
test: Cover regex match timeout

### DIFF
--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -961,6 +961,9 @@ Current Slice 6 progress:
   inside character classes, unsupported-looking tokens inside regex comments,
   Ruby-compatible first-`)` regex comment termination, and bounded possessive
   quantifiers such as `{1,3}+` and `{2,}+`.
+- A focused parser regression lowers regexp2's match timeout for a catastrophic
+  backtracking pattern and proves matches fail with a timeout instead of running
+  unbounded.
 
 ### Slice 7: Divergence Removal And Codebase Cleanup
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -2,10 +2,13 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/conditional/internal/ast"
 	"github.com/buildkite/conditional/internal/lexer"
+	"github.com/dlclark/regexp2"
 )
 
 func TestIntegerLiteralExpression(t *testing.T) {
@@ -71,6 +74,33 @@ func TestRegexpExpression(t *testing.T) {
 	}
 	if literal.Regexp.MatchTimeout != regexpMatchTimeout {
 		t.Errorf("regexp.MatchTimeout not %v. got=%v", regexpMatchTimeout, literal.Regexp.MatchTimeout)
+	}
+}
+
+func TestRegexpMatchTimeoutBoundsBacktracking(t *testing.T) {
+	l := lexer.New(`/(a+)+$/`)
+	p := New(l)
+	expr := p.Parse()
+	checkParserErrors(t, p)
+
+	literal, ok := expr.(*ast.Regexp)
+	if !ok {
+		t.Fatalf("exp not *ast.Regexp. got=%T", expr)
+	}
+
+	regexp2.SetTimeoutCheckPeriod(time.Millisecond)
+	t.Cleanup(func() {
+		regexp2.SetTimeoutCheckPeriod(regexp2.DefaultClockPeriod)
+		regexp2.StopTimeoutClock()
+	})
+
+	literal.Regexp.MatchTimeout = 5 * time.Millisecond
+	_, err := literal.Regexp.MatchString(strings.Repeat("a", 2000) + "!")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "timeout") {
+		t.Fatalf("expected timeout error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
The regex parity slice already sets a bounded regexp2 match timeout, but the test suite only checked the configured timeout value. That did not prove catastrophic backtracking actually fails fast under the matcher.

This adds a focused parser regression that lowers the timeout for one catastrophic pattern and asserts regexp2 returns a timeout error. The test resets regexp2 global timeout state afterward and runs in roughly tens of milliseconds.

The parity plan now records timeout behavior as covered for Slice 6.