### PR TITLE
feat: Add optional conformance oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ func main() {
 
 ## Conformance oracle
 
-Committed conformance cases can be checked locally with:
+Committed oracle seed cases can be checked locally with:
 
 ```sh
 mise run conformance:check
 ```
 
-To compare those cases with a server-backed oracle, set
+To compare that corpus with a server-backed oracle, set
 `CONDITIONAL_ORACLE_COMMAND` or pass `--oracle-command`:
 
 ```sh
@@ -133,6 +133,8 @@ go run ./cmd/conditional conformance --oracle-command ./server-oracle
 The command sends one JSON request on stdin for each case. The oracle should
 write a JSON response such as `{"result":true}` or `{"error_kind":"parse"}`.
 Use `go run ./cmd/conditional conformance --list` to inspect the request shape.
+The oracle corpus is separate from the broader root unit test suite so it can be
+expanded deliberately as server-backed coverage grows.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ func main() {
 }
 ```
 
+## Conformance oracle
+
+Committed conformance cases can be checked locally with:
+
+```sh
+mise run conformance:check
+```
+
+To compare those cases with a server-backed oracle, set
+`CONDITIONAL_ORACLE_COMMAND` or pass `--oracle-command`:
+
+```sh
+go run ./cmd/conditional conformance --oracle-command ./server-oracle
+```
+
+The command sends one JSON request on stdin for each case. The oracle should
+write a JSON response such as `{"result":true}` or `{"error_kind":"parse"}`.
+Use `go run ./cmd/conditional conformance --list` to inspect the request shape.
+
 ## Design
 
 The root package is the public Buildkite API:

--- a/cmd/conditional/conformance.go
+++ b/cmd/conditional/conformance.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/buildkite/conditional/internal/conformance"
@@ -105,7 +106,8 @@ func runOracle(command string, timeout time.Duration, request conformance.Oracle
 	}
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd := exec.Command("sh", "-c", command)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stdin = bytes.NewReader(payload)
 
 	var stdout bytes.Buffer
@@ -113,14 +115,32 @@ func runOracle(command string, timeout time.Duration, request conformance.Oracle
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
+		return conformance.Result{}, err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	var waitErr error
+	select {
+	case waitErr = <-done:
+	case <-ctx.Done():
+		killProcessGroup(cmd)
+		<-done
+		waitErr = ctx.Err()
+	}
+
+	if waitErr != nil {
 		if ctx.Err() != nil {
 			return conformance.Result{}, ctx.Err()
 		}
 		if stderr.Len() > 0 {
-			return conformance.Result{}, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+			return conformance.Result{}, fmt.Errorf("%w: %s", waitErr, strings.TrimSpace(stderr.String()))
 		}
-		return conformance.Result{}, err
+		return conformance.Result{}, waitErr
 	}
 
 	var result conformance.Result
@@ -128,4 +148,11 @@ func runOracle(command string, timeout time.Duration, request conformance.Oracle
 		return conformance.Result{}, fmt.Errorf("decode oracle response: %w", err)
 	}
 	return result, nil
+}
+
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }

--- a/cmd/conditional/conformance.go
+++ b/cmd/conditional/conformance.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/buildkite/conditional/internal/conformance"
+)
+
+func runConformance(args []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("conformance", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	list := flags.Bool("list", false, "write conformance cases as JSON lines")
+	oracleCommand := flags.String("oracle-command", os.Getenv("CONDITIONAL_ORACLE_COMMAND"), "external server oracle command")
+	oracleTimeout := flags.Duration("oracle-timeout", 30*time.Second, "timeout for each oracle case")
+
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+
+	cases := conformance.Cases()
+	if *list {
+		return writeConformanceCases(stdout, cases)
+	}
+
+	if err := verifyLocalConformance(cases); err != nil {
+		return err
+	}
+
+	if *oracleCommand == "" {
+		fmt.Fprintf(stdout, "local conformance cases passed: %d\n", len(cases))
+		fmt.Fprintln(stdout, "no server oracle configured; set CONDITIONAL_ORACLE_COMMAND or pass --oracle-command to compare")
+		return nil
+	}
+
+	return compareWithOracle(cases, *oracleCommand, *oracleTimeout, stdout, stderr)
+}
+
+func writeConformanceCases(w io.Writer, cases []conformance.Case) error {
+	enc := json.NewEncoder(w)
+	for _, c := range cases {
+		if err := enc.Encode(conformance.OracleRequestFor(c)); err != nil {
+			return fmt.Errorf("write case %q: %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+func verifyLocalConformance(cases []conformance.Case) error {
+	for _, c := range cases {
+		expected := conformance.Expected(c)
+		actual := conformance.EvaluateLocal(c)
+		if err := conformance.Compare(c.Mode, expected, actual); err != nil {
+			return fmt.Errorf("local conformance case %q failed: %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+func compareWithOracle(cases []conformance.Case, command string, timeout time.Duration, stdout, stderr io.Writer) error {
+	mismatches := 0
+	for _, c := range cases {
+		expected := conformance.Expected(c)
+		actual, err := runOracle(command, timeout, conformance.OracleRequestFor(c))
+		if err != nil {
+			return fmt.Errorf("oracle failed for %q: %w", c.Name, err)
+		}
+		if err := conformance.Compare(c.Mode, expected, actual); err != nil {
+			mismatches++
+			fmt.Fprintf(stderr, "mismatch %q: %v\n", c.Name, err)
+		}
+	}
+	if mismatches > 0 {
+		return fmt.Errorf("server oracle mismatches: %d of %d", mismatches, len(cases))
+	}
+
+	fmt.Fprintf(stdout, "server oracle conformance passed: %d cases\n", len(cases))
+	return nil
+}
+
+func runOracle(command string, timeout time.Duration, request conformance.OracleRequest) (conformance.Result, error) {
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return conformance.Result{}, fmt.Errorf("marshal request: %w", err)
+	}
+
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Stdin = bytes.NewReader(payload)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return conformance.Result{}, ctx.Err()
+		}
+		if stderr.Len() > 0 {
+			return conformance.Result{}, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+		}
+		return conformance.Result{}, err
+	}
+
+	var result conformance.Result
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		return conformance.Result{}, fmt.Errorf("decode oracle response: %w", err)
+	}
+	return result, nil
+}

--- a/cmd/conditional/conformance_test.go
+++ b/cmd/conditional/conformance_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRunConformanceLocalOnly(t *testing.T) {
+	t.Setenv("CONDITIONAL_ORACLE_COMMAND", "")
+
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 

--- a/cmd/conditional/conformance_test.go
+++ b/cmd/conditional/conformance_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/conditional/internal/conformance"
+)
+
+func TestRunConformanceLocalOnly(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := runConformance(nil, &stdout, &stderr); err != nil {
+		t.Fatalf("runConformance returned error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "local conformance cases passed") {
+		t.Fatalf("stdout = %q, want local conformance summary", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "no server oracle configured") {
+		t.Fatalf("stdout = %q, want oracle configuration hint", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunConformanceList(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := runConformance([]string{"--list"}, &stdout, &stderr); err != nil {
+		t.Fatalf("runConformance returned error: %v", err)
+	}
+
+	dec := json.NewDecoder(&stdout)
+	count := 0
+	for {
+		var request conformance.OracleRequest
+		if err := dec.Decode(&request); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatalf("decode request %d: %v", count, err)
+		}
+		if request.Name == "" || request.Source == "" || request.Expression == "" {
+			t.Fatalf("request %d missing identifying fields: %#v", count, request)
+		}
+		count++
+	}
+	if count != len(conformance.Cases()) {
+		t.Fatalf("listed %d cases, want %d", count, len(conformance.Cases()))
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunConformanceReportsOracleMismatches(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := runConformance([]string{"--oracle-command", `printf '{"result":false}\n'`}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("runConformance returned nil error, want mismatch")
+	}
+	if !strings.Contains(err.Error(), "server oracle mismatches") {
+		t.Fatalf("error = %v, want mismatch summary", err)
+	}
+	if !strings.Contains(stderr.String(), "mismatch") {
+		t.Fatalf("stderr = %q, want mismatch details", stderr.String())
+	}
+}
+
+func TestRunOracleDecodesResult(t *testing.T) {
+	result, err := runOracle(`printf '{"result":true}\n'`, 0, conformance.OracleRequest{})
+	if err != nil {
+		t.Fatalf("runOracle returned error: %v", err)
+	}
+	if result.Result == nil || !*result.Result {
+		t.Fatalf("result = %#v, want true", result)
+	}
+}
+
+func TestRunOracleReportsCommandFailure(t *testing.T) {
+	_, err := runOracle(`printf 'nope' >&2; exit 7`, 0, conformance.OracleRequest{})
+	if err == nil {
+		t.Fatal("runOracle returned nil error, want command failure")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("error = %v, want stderr context", err)
+	}
+}
+
+func TestRunOracleReportsBadJSON(t *testing.T) {
+	_, err := runOracle(`printf 'not-json\n'`, 0, conformance.OracleRequest{})
+	if err == nil {
+		t.Fatal("runOracle returned nil error, want decode failure")
+	}
+	if !strings.Contains(err.Error(), "decode oracle response") {
+		t.Fatalf("error = %v, want decode context", err)
+	}
+}
+
+func TestRunConformanceRejectsExtraArgs(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := runConformance([]string{"extra"}, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("runConformance returned nil error, want unexpected argument error")
+	}
+	if !strings.Contains(err.Error(), "unexpected arguments") {
+		t.Fatalf("error = %v, want unexpected arguments", err)
+	}
+}
+
+func TestRunOracleReportsTimeout(t *testing.T) {
+	_, err := runOracle(`sleep 1`, 1, conformance.OracleRequest{})
+	if err == nil {
+		t.Fatal("runOracle returned nil error, want timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want deadline exceeded", err)
+	}
+}

--- a/cmd/conditional/main.go
+++ b/cmd/conditional/main.go
@@ -8,6 +8,14 @@ import (
 )
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "conformance" {
+		if err := runConformance(os.Args[2:], os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	fmt.Println("Buildkite condition evaluator")
 	repl.Start(os.Stdin, os.Stdout)
 }

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -439,9 +439,9 @@ from this plan.
   accepted those names; the new table tests make that contract durable for both
   `env()` and `build.env()`, including GitHub deployment, check-run, comment,
   release, and review variables supplied through `BuildEnv`.
-- Slice 8, the optional server oracle, remains the only planned delivery slice
-  that has not landed. It should stay optional unless the team has reliable
-  server-backed fixtures and credentials for a non-CI conformance command.
+- Slice 8 has landed as an optional oracle command. Default CI still runs only
+  deterministic Go tests; server-backed comparison is available through
+  `mise run conformance:check` when `CONDITIONAL_ORACLE_COMMAND` is configured.
 
 ### Known Gaps
 
@@ -1001,6 +1001,24 @@ Definition of done:
 - If a live oracle is not available, the plan records exactly which semantics
   remain inferred from docs rather than server-proven.
 
+Current Slice 8 progress:
+
+- `internal/conformance` now contains a source-tagged conformance corpus that is
+  exercised locally by Go tests and by the optional command.
+- `go run ./cmd/conditional conformance` verifies the local corpus and reports
+  that no server oracle is configured.
+- `go run ./cmd/conditional conformance --list` writes the oracle request shape
+  as JSON lines.
+- `go run ./cmd/conditional conformance --oracle-command ./server-oracle`
+  streams each case to an external server-backed command and reports mismatches.
+- `mise run conformance:check` is available for local use, but it remains
+  separate from the default `mise run check` path.
+- A live server oracle command is still an optional private wrapper because this
+  public repo should not own Buildkite credentials, server fixtures, or network
+  calls in deterministic tests.
+
+Status: landed.
+
 ## Verification
 
 Run on every implementation slice:
@@ -1078,8 +1096,9 @@ Add these targeted checks as the plan lands:
 
 ## Deferred Work
 
-- Optional live server oracle. Ported upstream specs should carry the first
-  several implementation slices.
+- A private server-backed oracle command can be added wherever Buildkite
+  credentials and fixtures live. The public repo now has the command protocol
+  and committed corpus needed to run it.
 - Byte-for-byte error text if the first release can provide stable typed errors,
   source locations, and exact accept/reject behavior.
 

--- a/docs/plans/buildkite-conditionals-parity.md
+++ b/docs/plans/buildkite-conditionals-parity.md
@@ -1003,7 +1003,7 @@ Definition of done:
 
 Current Slice 8 progress:
 
-- `internal/conformance` now contains a source-tagged conformance corpus that is
+- `internal/conformance` now contains a source-tagged seed oracle corpus that is
   exercised locally by Go tests and by the optional command.
 - `go run ./cmd/conditional conformance` verifies the local corpus and reports
   that no server oracle is configured.
@@ -1016,6 +1016,9 @@ Current Slice 8 progress:
 - A live server oracle command is still an optional private wrapper because this
   public repo should not own Buildkite credentials, server fixtures, or network
   calls in deterministic tests.
+- The oracle corpus is intentionally separate from the broader root unit test
+  tables for now. Future hardening can migrate more of those source-tagged root
+  cases into `internal/conformance` as server-backed coverage grows.
 
 Status: landed.
 
@@ -1099,6 +1102,8 @@ Add these targeted checks as the plan lands:
 - A private server-backed oracle command can be added wherever Buildkite
   credentials and fixtures live. The public repo now has the command protocol
   and committed corpus needed to run it.
+- The broader source-tagged root test tables can be migrated into the oracle
+  corpus when the team wants a larger server-backed comparison set.
 - Byte-for-byte error text if the first release can provide stable typed errors,
   source locations, and exact accept/reject behavior.
 

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -1,0 +1,264 @@
+// Package conformance contains source-tagged Buildkite conditional cases used by
+// local tests and optional server-oracle tooling.
+package conformance
+
+import (
+	"fmt"
+
+	"github.com/buildkite/conditional"
+)
+
+// Mode identifies which root API operation a conformance case exercises.
+type Mode string
+
+const (
+	// ModeEvaluate evaluates an expression and expects a boolean or error kind.
+	ModeEvaluate Mode = "evaluate"
+	// ModeValidate validates an expression and expects success or an error kind.
+	ModeValidate Mode = "validate"
+)
+
+// Case is one Buildkite conditional conformance case.
+type Case struct {
+	Name       string                `json:"name"`
+	Source     string                `json:"source"`
+	Mode       Mode                  `json:"mode"`
+	Expression string                `json:"expression"`
+	Context    conditional.Context   `json:"context"`
+	WantResult *bool                 `json:"want_result,omitempty"`
+	WantError  conditional.ErrorKind `json:"want_error,omitempty"`
+}
+
+// Result is the normalized outcome returned by the local evaluator or an
+// optional server oracle.
+type Result struct {
+	Result    *bool                 `json:"result,omitempty"`
+	ErrorKind conditional.ErrorKind `json:"error_kind,omitempty"`
+}
+
+// OracleRequest is the JSON payload sent to an external server-oracle command.
+type OracleRequest struct {
+	Name       string              `json:"name"`
+	Source     string              `json:"source"`
+	Mode       Mode                `json:"mode"`
+	Expression string              `json:"expression"`
+	Context    conditional.Context `json:"context"`
+}
+
+// Cases returns the committed conformance corpus for optional server comparison.
+func Cases() []Case {
+	return []Case{
+		{
+			Name:       "docs branch is main or production",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.branch == "main" || build.branch == "production"`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				Build:      conditional.Build{Branch: str("main")},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "docs feature branch regex",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.branch =~ /^features\//`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				Build:      conditional.Build{Branch: str("features/api")},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "docs tag regex via build env",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.env("BUILDKITE_TAG") =~ /^v[0-9]+\.0$/`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				Build:      conditional.Build{Tag: str("v2.0")},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "docs custom build env",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.env("CUSTOM_ENVIRONMENT_VARIABLE") == "value"`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				BuildEnv:   map[string]string{"CUSTOM_ENVIRONMENT_VARIABLE": "value"},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "docs creator teams includes deploy",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.creator.teams includes "deploy"`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				Build: conditional.Build{
+					Creator: conditional.Actor{Teams: []string{"deploy", "platform"}},
+				},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "docs merge queue base branch",
+			Source:     docsConditionalsSource,
+			Mode:       ModeEvaluate,
+			Expression: `build.merge_queue.base_branch == "main"`,
+			Context: conditional.Context{
+				EntryPoint: conditional.EntryPointBuildCondition,
+				Build: conditional.Build{
+					MergeQueue: conditional.MergeQueue{BaseBranch: str("main")},
+				},
+			},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "upstream null regex match is false",
+			Source:     upstreamEvaluatorSpec,
+			Mode:       ModeEvaluate,
+			Expression: `null =~ /main|development/`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildCondition},
+			WantResult: boolptr(false),
+		},
+		{
+			Name:       "upstream shell substitution default",
+			Source:     upstreamEvaluatorSpec,
+			Mode:       ModeEvaluate,
+			Expression: `${notset:-fallback} == "fallback"`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildCondition},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "upstream ternary alternative branch",
+			Source:     upstreamEvaluatorSpec,
+			Mode:       ModeEvaluate,
+			Expression: `1 == 2 ? 3 == 4 : 5 == 5`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildCondition},
+			WantResult: boolptr(true),
+		},
+		{
+			Name:       "build notification parse errors are false",
+			Source:     upstreamBuildNotificationSpec,
+			Mode:       ModeEvaluate,
+			Expression: `nope != == one`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildNotification},
+			WantResult: boolptr(false),
+		},
+		{
+			Name:       "validate rejects unsupported Buildkite env",
+			Source:     upstreamBuildConditionSpec,
+			Mode:       ModeValidate,
+			Expression: `build.env("BUILDKITE_AGENT_ACCESS_TOKEN") == null`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildCondition},
+			WantError:  conditional.ErrorKindValidation,
+		},
+		{
+			Name:       "validate rejects step variables without step entrypoint",
+			Source:     upstreamBuildValidatorSpec,
+			Mode:       ModeValidate,
+			Expression: `step.outcome == "hard_failed"`,
+			Context:    conditional.Context{EntryPoint: conditional.EntryPointBuildCondition},
+			WantError:  conditional.ErrorKindValidation,
+		},
+	}
+}
+
+// Expected returns the normalized expected result for a case.
+func Expected(c Case) Result {
+	if c.WantError != "" {
+		return Result{ErrorKind: c.WantError}
+	}
+	return Result{Result: c.WantResult}
+}
+
+// OracleRequestFor returns the request payload for a case.
+func OracleRequestFor(c Case) OracleRequest {
+	return OracleRequest{
+		Name:       c.Name,
+		Source:     c.Source,
+		Mode:       c.Mode,
+		Expression: c.Expression,
+		Context:    c.Context,
+	}
+}
+
+// EvaluateLocal evaluates a case through the local root package API.
+func EvaluateLocal(c Case) Result {
+	switch c.Mode {
+	case ModeEvaluate:
+		got, err := conditional.Evaluate(c.Expression, c.Context)
+		if err != nil {
+			return Result{ErrorKind: errorKind(err)}
+		}
+		return Result{Result: boolptr(got)}
+	case ModeValidate:
+		if err := conditional.Validate(c.Expression, c.Context); err != nil {
+			return Result{ErrorKind: errorKind(err)}
+		}
+		return Result{}
+	default:
+		return Result{ErrorKind: conditional.ErrorKindValidation}
+	}
+}
+
+// Compare reports whether an actual result matches the expected result for mode.
+func Compare(mode Mode, expected, actual Result) error {
+	if expected.ErrorKind != actual.ErrorKind {
+		return fmt.Errorf("error kind = %q, want %q", actual.ErrorKind, expected.ErrorKind)
+	}
+	if expected.ErrorKind != "" {
+		return nil
+	}
+	switch mode {
+	case ModeEvaluate:
+		if expected.Result == nil || actual.Result == nil {
+			return fmt.Errorf("result = %v, want %v", actual.Result, expected.Result)
+		}
+		if *actual.Result != *expected.Result {
+			return fmt.Errorf("result = %t, want %t", *actual.Result, *expected.Result)
+		}
+	case ModeValidate:
+		if actual.Result != nil {
+			return fmt.Errorf("validation returned result %t", *actual.Result)
+		}
+	default:
+		return fmt.Errorf("unsupported mode %q", mode)
+	}
+	return nil
+}
+
+func errorKind(err error) conditional.ErrorKind {
+	for _, kind := range []conditional.ErrorKind{
+		conditional.ErrorKindParse,
+		conditional.ErrorKindValidation,
+		conditional.ErrorKindEvaluation,
+		conditional.ErrorKindResult,
+	} {
+		if conditional.IsErrorKind(err, kind) {
+			return kind
+		}
+	}
+	return conditional.ErrorKindEvaluation
+}
+
+const (
+	docsConditionalsSource        = "https://buildkite.com/docs/pipelines/configure/conditionals"
+	upstreamEvaluatorSpec         = "buildkite/buildkite:spec/models/conditional/evaluator_spec.rb"
+	upstreamBuildConditionSpec    = "buildkite/buildkite:spec/models/build/condition_spec.rb"
+	upstreamBuildValidatorSpec    = "buildkite/buildkite:spec/validators/build_condition_validator_spec.rb"
+	upstreamBuildNotificationSpec = "buildkite/buildkite:spec/models/build/notification_spec.rb"
+)
+
+func str(value string) *string {
+	return &value
+}
+
+func boolptr(value bool) *bool {
+	return &value
+}

--- a/internal/conformance/conformance.go
+++ b/internal/conformance/conformance.go
@@ -209,6 +209,9 @@ func EvaluateLocal(c Case) Result {
 
 // Compare reports whether an actual result matches the expected result for mode.
 func Compare(mode Mode, expected, actual Result) error {
+	if actual.ErrorKind != "" && actual.Result != nil {
+		return fmt.Errorf("result must be empty when error_kind is %q", actual.ErrorKind)
+	}
 	if expected.ErrorKind != actual.ErrorKind {
 		return fmt.Errorf("error kind = %q, want %q", actual.ErrorKind, expected.ErrorKind)
 	}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -1,0 +1,22 @@
+package conformance
+
+import "testing"
+
+func TestCasesMatchLocalEvaluator(t *testing.T) {
+	for _, c := range Cases() {
+		t.Run(c.Name, func(t *testing.T) {
+			if c.Source == "" {
+				t.Fatal("case source is empty")
+			}
+			if c.Expression == "" {
+				t.Fatal("case expression is empty")
+			}
+
+			expected := Expected(c)
+			actual := EvaluateLocal(c)
+			if err := Compare(c.Mode, expected, actual); err != nil {
+				t.Fatalf("local result mismatch: %v", err)
+			}
+		})
+	}
+}

--- a/internal/conformance/conformance_test.go
+++ b/internal/conformance/conformance_test.go
@@ -20,3 +20,14 @@ func TestCasesMatchLocalEvaluator(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareRejectsResultWithErrorKind(t *testing.T) {
+	result := true
+	err := Compare(ModeValidate, Result{ErrorKind: "validation"}, Result{
+		Result:    &result,
+		ErrorKind: "validation",
+	})
+	if err == nil {
+		t.Fatal("Compare returned nil error, want protocol violation")
+	}
+}

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,10 @@ run = [
 description = "Run all tests"
 run = "go test ./..."
 
+[tasks."conformance:check"]
+description = "Run the optional conformance oracle check"
+run = "go run ./cmd/conditional conformance"
+
 [tasks.lint]
 description = "Run linter"
 run = [


### PR DESCRIPTION
The parity plan calls for a way to compare committed Go conformance cases with server behavior, but default unit tests should stay deterministic and credential-free.

This adds an internal source-tagged conformance corpus, a `conditional conformance` command, and a `mise run conformance:check` task. With no oracle configured, the command verifies the local corpus. With `CONDITIONAL_ORACLE_COMMAND` or `--oracle-command`, it streams each case as JSON to a server-backed wrapper and reports mismatches.

The request payload deliberately does not include expected results, so an oracle has to evaluate the case rather than echoing local expectations. The README documents the protocol and the plan now marks Slice 8 as landed while leaving private server credentials and fixtures out of this public repo.