### PR TITLE
docs: Add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Buildkite Conditional Evaluator
 
+[![Build status](https://badge.buildkite.com/e7ce8917b2bbb76ee5ee7a6d374b019ab56fad137ef05ee070.svg?branch=master)](https://buildkite.com/buildkite/conditional)
+[![Release](https://img.shields.io/github/v/release/buildkite/conditional?label=Release)](https://github.com/buildkite/conditional/releases)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 A Go library for validating and evaluating Buildkite conditional expressions
 with the same server-side syntax and semantics documented in
 [Using conditionals](https://buildkite.com/docs/pipelines/configure/conditionals).


### PR DESCRIPTION
The conditional README currently starts with text only, so readers have to leave the page to find CI or license state. This adds the relevant badge set used by `buildkite/cleanroom`, pointed at `buildkite/conditional`.

The badges show the `master` Buildkite status and MIT license at a glance. The Buildkite badge links to the conditional pipeline, while the license badge links to `LICENSE`.
