### PR TITLE
docs: Remove release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Buildkite Conditional Evaluator
 
 [![Build status](https://badge.buildkite.com/e7ce8917b2bbb76ee5ee7a6d374b019ab56fad137ef05ee070.svg?branch=master)](https://buildkite.com/buildkite/conditional)
-[![Release](https://img.shields.io/github/v/release/buildkite/conditional?label=Release)](https://github.com/buildkite/conditional/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A Go library for validating and evaluating Buildkite conditional expressions


### PR DESCRIPTION
The README now includes the same badge style as `buildkite/cleanroom`, but `conditional` has no tags or GitHub releases. Keeping a release badge would either render as empty/noisy or imply a release process that does not exist yet.

This keeps the useful README status signals: the `master` Buildkite status and MIT license. If `conditional` starts publishing versioned module releases later, the release badge can come back with an actual release process behind it.