### PR TITLE
fix: Return parser errors as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ for build condition entrypoints, while notification entrypoints return `false`
 for parse, validation, and evaluation errors. Blank notification conditionals
 evaluate to `true`, matching Buildkite notification deliverability.
 
+Returned errors are `*conditional.Error` values with a stable `Kind`. Parse
+errors also unwrap to the underlying parser errors, so callers can inspect the
+cause with `errors.Unwrap`.
+
 ## Usage
 
 Evaluate a build conditional:

--- a/conditional.go
+++ b/conditional.go
@@ -1,6 +1,7 @@
 package conditional
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -80,13 +81,25 @@ func parse(expression string) (ast.Expression, error) {
 	expr := p.Parse()
 
 	if errs := p.Errors(); len(errs) > 0 {
-		return nil, &Error{Kind: ErrorKindParse, Message: strings.Join(errs, "; ")}
+		return nil, &Error{
+			Kind:    ErrorKindParse,
+			Message: joinErrorMessages(errs),
+			Cause:   errors.Join(errs...),
+		}
 	}
 	if expr == nil {
 		return nil, &Error{Kind: ErrorKindParse, Message: "empty expression"}
 	}
 
 	return expr, nil
+}
+
+func joinErrorMessages(errs []error) string {
+	messages := make([]string, 0, len(errs))
+	for _, err := range errs {
+		messages = append(messages, err.Error())
+	}
+	return strings.Join(messages, "; ")
 }
 
 func validateExpression(expr ast.Expression, ctx Context) error {

--- a/conditional_test.go
+++ b/conditional_test.go
@@ -1,6 +1,10 @@
 package conditional
 
-import "testing"
+import (
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestRootValidateAndEvaluateErrorKinds(t *testing.T) {
 	tests := []evaluateCase{
@@ -63,4 +67,22 @@ func TestRootValidateErrorKinds(t *testing.T) {
 	}
 
 	runValidateCases(t, tests)
+}
+
+func TestParseErrorUnwrapsParserErrors(t *testing.T) {
+	err := Validate(`nope != == one`, Context{EntryPoint: EntryPointBuildCondition})
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !IsErrorKind(err, ErrorKindParse) {
+		t.Fatalf("expected parse error kind, got %v", err)
+	}
+
+	cause := errors.Unwrap(err)
+	if cause == nil {
+		t.Fatal("expected parse error to unwrap to parser errors")
+	}
+	if !strings.Contains(cause.Error(), "no prefix parse function for == found") {
+		t.Fatalf("unexpected parse cause: %v", cause)
+	}
 }

--- a/errors.go
+++ b/errors.go
@@ -20,7 +20,8 @@ const (
 	ErrorKindResult ErrorKind = "result"
 )
 
-// Error is a typed conditional error.
+// Error is a typed conditional error. Cause contains a lower-level error when
+// one is useful to expose through Unwrap.
 type Error struct {
 	Kind    ErrorKind
 	Message string

--- a/internal/evaluator/evaluator_test.go
+++ b/internal/evaluator/evaluator_test.go
@@ -379,7 +379,7 @@ func testEvalWithScope(input string, scope Scope) object.Object {
 	p := parser.New(l)
 	expr := p.Parse()
 	if len(p.Errors()) > 0 {
-		return &object.Error{Message: p.Errors()[0]}
+		return &object.Error{Message: p.Errors()[0].Error()}
 	}
 	return Eval(expr, scope)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -43,7 +44,7 @@ type (
 
 type Parser struct {
 	l      *lexer.Lexer
-	errors []string
+	errors []error
 
 	curToken  token.Token
 	peekToken token.Token
@@ -55,7 +56,7 @@ type Parser struct {
 func New(l *lexer.Lexer) *Parser {
 	p := &Parser{
 		l:      l,
-		errors: []string{},
+		errors: []error{},
 	}
 
 	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
@@ -112,26 +113,26 @@ func (p *Parser) expectPeek(t token.TokenType) bool {
 	}
 }
 
-func (p *Parser) Errors() []string {
+func (p *Parser) Errors() []error {
 	return p.errors
 }
 
 func (p *Parser) peekError(t token.TokenType) {
-	msg := fmt.Sprintf("expected next token to be %s, got %s instead",
-		t, p.peekToken.Type)
-	p.errors = append(p.errors, msg)
+	p.errors = append(p.errors, fmt.Errorf(
+		"expected next token to be %s, got %s instead",
+		t, p.peekToken.Type,
+	))
 }
 
 func (p *Parser) noPrefixParseFnError(t token.TokenType) {
-	msg := fmt.Sprintf("no prefix parse function for %s found", t)
-	p.errors = append(p.errors, msg)
+	p.errors = append(p.errors, fmt.Errorf("no prefix parse function for %s found", t))
 }
 
 func (p *Parser) Parse() ast.Expression {
 	// defer untrace(trace("Parse"))
 
 	if p.curToken.Type == token.EOF {
-		p.errors = append(p.errors, "empty expression")
+		p.errors = append(p.errors, errors.New("empty expression"))
 		return nil
 	}
 
@@ -141,9 +142,10 @@ func (p *Parser) Parse() ast.Expression {
 	}
 
 	if !p.peekTokenIs(token.EOF) {
-		msg := fmt.Sprintf("unexpected token after expression: %s (%q)",
-			p.peekToken.Type, p.peekToken.Literal)
-		p.errors = append(p.errors, msg)
+		p.errors = append(p.errors, fmt.Errorf(
+			"unexpected token after expression: %s (%q)",
+			p.peekToken.Type, p.peekToken.Literal,
+		))
 	}
 
 	return exp
@@ -192,8 +194,7 @@ func (p *Parser) curPrecedence() int {
 func (p *Parser) parseIdentifier() ast.Expression {
 	// defer untrace(trace("parseIdentifier", p.curToken))
 	if invalidDottedIdentifier(p.curToken.Literal) {
-		msg := fmt.Sprintf("invalid dotted identifier: %s", p.curToken.Literal)
-		p.errors = append(p.errors, msg)
+		p.errors = append(p.errors, fmt.Errorf("invalid dotted identifier: %s", p.curToken.Literal))
 		return nil
 	}
 	return &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
@@ -209,8 +210,7 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 
 	value, err := strconv.ParseInt(p.curToken.Literal, 0, 64)
 	if err != nil {
-		msg := fmt.Sprintf("could not parse %q as integer", p.curToken.Literal)
-		p.errors = append(p.errors, msg)
+		p.errors = append(p.errors, fmt.Errorf("could not parse %q as integer", p.curToken.Literal))
 		return nil
 	}
 
@@ -232,7 +232,7 @@ func (p *Parser) parseRegexp() ast.Expression {
 
 	r, err := regex.Compile(p.curToken.Literal, p.curToken.Flags)
 	if err != nil {
-		p.errors = append(p.errors, err.Error())
+		p.errors = append(p.errors, err)
 		return nil
 	}
 	ar.Regexp = r
@@ -318,8 +318,7 @@ func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
 
 	name, ok := functionName(function)
 	if !ok {
-		msg := fmt.Sprintf("function call must be an identifier, got %v", p.curToken.Type)
-		p.errors = append(p.errors, msg)
+		p.errors = append(p.errors, fmt.Errorf("function call must be an identifier, got %v", p.curToken.Type))
 		return nil
 	}
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -678,8 +678,8 @@ func checkParserErrors(t *testing.T, p *Parser) {
 	}
 
 	t.Errorf("parser has %d errors", len(errors))
-	for _, msg := range errors {
-		t.Errorf("parser error: %q", msg)
+	for _, err := range errors {
+		t.Errorf("parser error: %q", err.Error())
 	}
 	t.FailNow()
 }


### PR DESCRIPTION
Issue #6 has been open since the parser reported errors as display strings. We are currently breaking internal and public API shape for this library, so this is the right time to switch parser errors over to real errors instead of carrying the string API forward.

This changes `internal/parser.Parser.Errors()` from `[]string` to `[]error`. The root package keeps `Validate` and `Evaluate` returning a single `error`, but parse failures now populate `conditional.Error.Cause` with `errors.Join(errs...)` while preserving the existing parse kind and message text.

For callers, `Validate("nope != == one", ctx)` still returns a `*conditional.Error` with `Kind == ErrorKindParse`, and `errors.Unwrap(err)` now exposes the underlying parser errors.