### PR TITLE
feat: Add pluggable conditional functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Buildkite values that would be available at the selected entrypoint.
   expressions
 * Buildkite identifiers such as `build.branch`
 * Function calls such as `env("FOO")` and `build.env("FOO")`; dotted function
-  names are parsed as flat Buildkite function names
+  names are parsed as flat function names
 * Prefix negation: `!`
 * Array membership: `["foo", "bar"] includes "foo"`
 * Shell-style environment substitution in operands and double-quoted strings
@@ -146,6 +146,58 @@ evaluate to `true`, matching Buildkite notification deliverability.
 Returned errors are `*conditional.Error` values with a stable `Kind`. Parse
 errors also unwrap to the underlying parser errors, so callers can inspect the
 cause with `errors.Unwrap`.
+
+## Extensions
+
+`Validate` and `Evaluate` accept variadic options. With no options, the library
+keeps the Buildkite server-parity contract and rejects unknown functions.
+Callers can opt into additional functions for their own expression surface.
+`Context` remains the per-call Buildkite state; options configure evaluator
+capabilities.
+
+Use per-call options when a custom function is only needed in one place:
+
+```go
+startsWith := conditional.WithFunction("starts_with", conditional.Function{
+	Args:   []conditional.ValueType{conditional.StringType, conditional.StringType},
+	Return: conditional.BoolType,
+	Eval: func(args []conditional.Value) (conditional.Value, error) {
+		value, _ := args[0].AsString()
+		prefix, _ := args[1].AsString()
+		return conditional.BoolValue(strings.HasPrefix(value, prefix)), nil
+	},
+})
+
+ok, err := conditional.Evaluate(
+	`starts_with(build.branch, "release/")`,
+	ctx,
+	startsWith,
+)
+```
+
+Use `NewEvaluator` when the same options should be reused across many
+validations or evaluations:
+
+```go
+evaluator, err := conditional.NewEvaluator(startsWith)
+if err != nil {
+	log.Fatal(err)
+}
+
+ok, err := evaluator.Evaluate(
+	`starts_with(build.branch, "release/")`,
+	ctx,
+)
+```
+
+`NewEvaluator` validates options once. The zero value `Evaluator` has no custom
+functions and behaves like the package-level Buildkite-parity helpers.
+
+Custom functions are type-checked before evaluation. Function arguments and
+return values use the exported `Value` and `ValueType` APIs, so callers do not
+depend on internal evaluator objects. The `build`, `env`, `organization`,
+`pipeline`, and `step` roots are reserved for Buildkite values and built-in
+functions.
 
 ## Usage
 

--- a/conditional.go
+++ b/conditional.go
@@ -14,11 +14,32 @@ import (
 )
 
 // Validate parses expression for the selected Buildkite context.
-func Validate(expression string, ctx Context) error {
+func Validate(expression string, ctx Context, opts ...Option) error {
 	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
 	if err != nil {
 		return err
 	}
+	options, err := applyOptions(opts)
+	if err != nil {
+		return err
+	}
+	return validate(expression, ctx, entryPoint, options)
+}
+
+// Evaluate evaluates expression in the selected Buildkite context.
+func Evaluate(expression string, ctx Context, opts ...Option) (bool, error) {
+	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
+	if err != nil {
+		return false, err
+	}
+	options, err := applyOptions(opts)
+	if err != nil {
+		return false, err
+	}
+	return evaluateWithOptions(expression, ctx, entryPoint, options)
+}
+
+func validate(expression string, ctx Context, entryPoint EntryPoint, options optionSet) error {
 	if strings.TrimSpace(expression) == "" {
 		return nil
 	}
@@ -28,38 +49,31 @@ func Validate(expression string, ctx Context) error {
 		return err
 	}
 	ctx.EntryPoint = entryPoint
-	return validateExpression(expr, ctx)
+	return validateExpression(expr, ctx, options)
 }
 
-// Evaluate evaluates expression in the selected Buildkite context.
-func Evaluate(expression string, ctx Context) (bool, error) {
-	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
-	if err != nil {
-		return false, err
-	}
-	ctx.EntryPoint = entryPoint
-
+func evaluateWithOptions(expression string, ctx Context, entryPoint EntryPoint, options optionSet) (bool, error) {
 	if strings.TrimSpace(expression) == "" && isNotificationEntryPoint(entryPoint) {
 		return true, nil
 	}
 
-	result, err := evaluate(expression, ctx)
+	result, err := evaluate(expression, ctx, options)
 	if err != nil && isNotificationEntryPoint(entryPoint) {
 		return false, nil
 	}
 	return result, err
 }
 
-func evaluate(expression string, ctx Context) (bool, error) {
+func evaluate(expression string, ctx Context, options optionSet) (bool, error) {
 	expr, err := parse(expression)
 	if err != nil {
 		return false, err
 	}
-	if err := validateExpression(expr, ctx); err != nil {
+	if err := validateExpression(expr, ctx, options); err != nil {
 		return false, err
 	}
 
-	result := evaluator.Eval(expr, buildScope(ctx))
+	result := evaluator.Eval(expr, buildScope(ctx, options))
 	switch result := result.(type) {
 	case *object.Boolean:
 		return result.Value, nil
@@ -102,7 +116,7 @@ func joinErrorMessages(errs []error) string {
 	return strings.Join(messages, "; ")
 }
 
-func validateExpression(expr ast.Expression, ctx Context) error {
+func validateExpression(expr ast.Expression, ctx Context, options optionSet) error {
 	entryPoint := ctx.EntryPoint
 	if !stepAllowed(entryPoint) && referencesRoot(expr, "step") {
 		return &Error{
@@ -113,7 +127,7 @@ func validateExpression(expr ast.Expression, ctx Context) error {
 	if err := validateEnvCalls(expr); err != nil {
 		return err
 	}
-	return typeCheckExpression(expr, ctx)
+	return typeCheckExpression(expr, ctx, options)
 }
 
 func validateEnvCalls(expr ast.Expression) error {
@@ -229,12 +243,15 @@ func (s evaluationScope) LookupEnv(key string) (string, bool) {
 	return value, ok
 }
 
-func buildScope(ctx Context) evaluationScope {
+func buildScope(ctx Context, options optionSet) evaluationScope {
 	env := mergedEnv(ctx)
 
 	scope := object.Struct{
 		"env":       envFunction(env),
 		"build.env": nullableEnvFunction(env),
+	}
+	for name, function := range options.functions {
+		scope[name] = function.objectFunction(name)
 	}
 	for key, value := range flatAssignments(ctx) {
 		scope[key] = value

--- a/doc.go
+++ b/doc.go
@@ -3,7 +3,9 @@
 //
 // The public API is the root package. Use Context to provide Buildkite values,
 // set Context.EntryPoint to the place where the conditional runs, then call
-// Validate or Evaluate.
+// Validate or Evaluate. Optional variadic options can register caller-owned
+// functions without changing default Buildkite server-parity behavior. Use
+// NewEvaluator to reuse options across multiple validations or evaluations.
 //
 // Validate always returns parse and validation errors. Evaluate returns errors
 // for build condition entrypoints. Notification entrypoints model Buildkite

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -1,0 +1,89 @@
+package conditional_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/conditional"
+)
+
+func ExampleWithFunction() {
+	branch := "release/2026-06-07"
+	startsWith := conditional.WithFunction("starts_with", conditional.Function{
+		Args:   []conditional.ValueType{conditional.StringType, conditional.StringType},
+		Return: conditional.BoolType,
+		Eval: func(args []conditional.Value) (conditional.Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return conditional.NullValue(), errors.New("value must be a string")
+			}
+			prefix, ok := args[1].AsString()
+			if !ok {
+				return conditional.NullValue(), errors.New("prefix must be a string")
+			}
+			return conditional.BoolValue(strings.HasPrefix(value, prefix)), nil
+		},
+	})
+
+	ok, err := conditional.Evaluate(
+		`starts_with(build.branch, "release/")`,
+		conditional.Context{
+			EntryPoint: conditional.EntryPointBuildCondition,
+			Build: conditional.Build{
+				Branch: &branch,
+			},
+		},
+		startsWith,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ok)
+
+	// Output:
+	// true
+}
+
+func ExampleNewEvaluator() {
+	branch := "release/2026-06-07"
+	startsWith := conditional.WithFunction("starts_with", conditional.Function{
+		Args:   []conditional.ValueType{conditional.StringType, conditional.StringType},
+		Return: conditional.BoolType,
+		Eval: func(args []conditional.Value) (conditional.Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return conditional.NullValue(), errors.New("value must be a string")
+			}
+			prefix, ok := args[1].AsString()
+			if !ok {
+				return conditional.NullValue(), errors.New("prefix must be a string")
+			}
+			return conditional.BoolValue(strings.HasPrefix(value, prefix)), nil
+		},
+	})
+
+	evaluator, err := conditional.NewEvaluator(startsWith)
+	if err != nil {
+		panic(err)
+	}
+
+	ok, err := evaluator.Evaluate(
+		`starts_with(build.branch, "release/")`,
+		conditional.Context{
+			EntryPoint: conditional.EntryPointBuildCondition,
+			Build: conditional.Build{
+				Branch: &branch,
+			},
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ok)
+
+	// Output:
+	// true
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,384 @@
+package conditional
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/conditional/internal/object"
+	"github.com/buildkite/conditional/internal/regex"
+)
+
+// Option configures conditional validation and evaluation.
+type Option func(*optionSet) error
+
+type optionSet struct {
+	functions map[string]Function
+}
+
+// Evaluator validates and evaluates conditionals with reusable options.
+//
+// The zero value is a Buildkite-parity evaluator with no caller-owned
+// functions.
+type Evaluator struct {
+	options optionSet
+}
+
+// NewEvaluator returns an evaluator with reusable options.
+func NewEvaluator(opts ...Option) (Evaluator, error) {
+	options, err := applyOptions(opts)
+	if err != nil {
+		return Evaluator{}, err
+	}
+	return Evaluator{options: options}, nil
+}
+
+// Validate parses expression for the selected Buildkite context using the
+// evaluator's options.
+func (e Evaluator) Validate(expression string, ctx Context) error {
+	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
+	if err != nil {
+		return err
+	}
+	return validate(expression, ctx, entryPoint, e.options)
+}
+
+// Evaluate evaluates expression in the selected Buildkite context using the
+// evaluator's options.
+func (e Evaluator) Evaluate(expression string, ctx Context) (bool, error) {
+	entryPoint, err := normalizeEntryPoint(ctx.EntryPoint)
+	if err != nil {
+		return false, err
+	}
+	return evaluateWithOptions(expression, ctx, entryPoint, e.options)
+}
+
+// Function defines an opt-in conditional function.
+type Function struct {
+	Args   []ValueType
+	Return ValueType
+	Eval   func(args []Value) (Value, error)
+}
+
+// ValueType describes a conditional value type.
+type ValueType string
+
+const (
+	// StringType is the conditional string type.
+	StringType ValueType = "string"
+	// NumberType is the conditional integer type.
+	NumberType ValueType = "number"
+	// BoolType is the conditional boolean type.
+	BoolType ValueType = "boolean"
+	// NullType is the conditional null type.
+	NullType ValueType = "null"
+	// RegexpType is the conditional regular expression type.
+	RegexpType ValueType = "regular expression"
+	// StringArrayType is the conditional string array type.
+	StringArrayType ValueType = "string array"
+)
+
+// String returns a human-readable value type description.
+func (t ValueType) String() string {
+	typ, err := t.internal()
+	if err != nil {
+		return "invalid"
+	}
+	return typ.describe()
+}
+
+func (t ValueType) internal() (valueType, error) {
+	switch t {
+	case StringType:
+		return stringType(), nil
+	case NumberType:
+		return numberType(), nil
+	case BoolType:
+		return boolType(), nil
+	case NullType:
+		return valueType{kind: kindNull}, nil
+	case RegexpType:
+		return valueType{kind: kindRegexp}, nil
+	case StringArrayType:
+		return stringArrayType(), nil
+	default:
+		return valueType{kind: kindUnknown}, validationError("invalid function value type")
+	}
+}
+
+// Value is a conditional runtime value.
+//
+// The zero value represents null.
+type Value struct {
+	obj object.Object
+}
+
+// StringValue returns a string value.
+func StringValue(value string) Value {
+	return Value{obj: &object.String{Value: value}}
+}
+
+// NumberValue returns an integer value.
+func NumberValue(value int64) Value {
+	return Value{obj: &object.Integer{Value: value}}
+}
+
+// BoolValue returns a boolean value.
+func BoolValue(value bool) Value {
+	return Value{obj: &object.Boolean{Value: value}}
+}
+
+// NullValue returns a null value.
+func NullValue() Value {
+	return Value{obj: &object.Null{}}
+}
+
+// RegexpValue returns a regular expression value.
+func RegexpValue(pattern string, flags string) (Value, error) {
+	compiled, err := regex.Compile(pattern, flags)
+	if err != nil {
+		return Value{}, err
+	}
+	return Value{obj: &object.Regexp{Regexp: compiled, Flags: flags}}, nil
+}
+
+// StringArrayValue returns a string array value.
+func StringArrayValue(values []string) Value {
+	elements := make([]object.Object, 0, len(values))
+	for _, value := range values {
+		elements = append(elements, &object.String{Value: value})
+	}
+	return Value{obj: &object.Array{Elements: elements}}
+}
+
+// Type returns the value's conditional type.
+func (v Value) Type() ValueType {
+	switch v.object().(type) {
+	case *object.String:
+		return StringType
+	case *object.Integer:
+		return NumberType
+	case *object.Boolean:
+		return BoolType
+	case *object.Null:
+		return NullType
+	case *object.Regexp:
+		return RegexpType
+	case *object.Array:
+		return StringArrayType
+	default:
+		return ValueType(kindUnknown)
+	}
+}
+
+// IsNull reports whether the value is null.
+func (v Value) IsNull() bool {
+	_, ok := v.object().(*object.Null)
+	return ok
+}
+
+// AsString returns the string value, if this value is a string.
+func (v Value) AsString() (string, bool) {
+	value, ok := v.object().(*object.String)
+	if !ok {
+		return "", false
+	}
+	return value.Value, true
+}
+
+// AsNumber returns the integer value, if this value is an integer.
+func (v Value) AsNumber() (int64, bool) {
+	value, ok := v.object().(*object.Integer)
+	if !ok {
+		return 0, false
+	}
+	return value.Value, true
+}
+
+// AsBool returns the boolean value, if this value is a boolean.
+func (v Value) AsBool() (bool, bool) {
+	value, ok := v.object().(*object.Boolean)
+	if !ok {
+		return false, false
+	}
+	return value.Value, true
+}
+
+// AsRegexp returns the regular expression pattern and flags, if this value is a
+// regular expression.
+func (v Value) AsRegexp() (pattern string, flags string, ok bool) {
+	value, ok := v.object().(*object.Regexp)
+	if !ok {
+		return "", "", false
+	}
+	return value.Regexp.String(), value.Flags, true
+}
+
+// AsStringArray returns a copy of the array values, if this value is a string
+// array.
+func (v Value) AsStringArray() ([]string, bool) {
+	value, ok := v.object().(*object.Array)
+	if !ok {
+		return nil, false
+	}
+
+	values := make([]string, 0, len(value.Elements))
+	for _, element := range value.Elements {
+		stringElement, ok := element.(*object.String)
+		if !ok {
+			return nil, false
+		}
+		values = append(values, stringElement.Value)
+	}
+	return values, true
+}
+
+// String returns a human-readable value representation.
+func (v Value) String() string {
+	return v.object().String()
+}
+
+func (v Value) object() object.Object {
+	if v.obj == nil {
+		return &object.Null{}
+	}
+	return v.obj
+}
+
+func valueFromObject(obj object.Object) Value {
+	return Value{obj: obj}
+}
+
+// WithFunction registers an opt-in conditional function.
+func WithFunction(name string, function Function) Option {
+	return func(options *optionSet) error {
+		if err := validateFunctionName(name); err != nil {
+			return err
+		}
+		if reservedFunctionName(name) {
+			return validationError("function `%s` uses a reserved Buildkite name", name)
+		}
+		if function.Eval == nil {
+			return validationError("function `%s` requires an Eval callback", name)
+		}
+		if _, err := function.signature(); err != nil {
+			return err
+		}
+
+		function.Args = append([]ValueType(nil), function.Args...)
+		if options.functions == nil {
+			options.functions = map[string]Function{}
+		}
+		if _, ok := options.functions[name]; ok {
+			return validationError("function `%s` is already registered", name)
+		}
+		options.functions[name] = function
+		return nil
+	}
+}
+
+func applyOptions(opts []Option) (optionSet, error) {
+	var options optionSet
+	for _, opt := range opts {
+		if opt == nil {
+			return optionSet{}, validationError("nil conditional option")
+		}
+		if err := opt(&options); err != nil {
+			return optionSet{}, err
+		}
+	}
+	return options, nil
+}
+
+func (f Function) signature() (functionSignature, error) {
+	args := make([]valueKind, 0, len(f.Args))
+	for _, arg := range f.Args {
+		typ, err := arg.internal()
+		if err != nil {
+			return functionSignature{}, err
+		}
+		args = append(args, typ.kind)
+	}
+
+	ret, err := f.Return.internal()
+	if err != nil {
+		return functionSignature{}, err
+	}
+
+	return functionSignature{args: args, ret: ret}, nil
+}
+
+func (f Function) objectFunction(name string) object.Function {
+	return func(args []object.Object) object.Object {
+		values := make([]Value, 0, len(args))
+		for _, arg := range args {
+			values = append(values, valueFromObject(arg))
+		}
+
+		result, err := f.Eval(values)
+		if err != nil {
+			return &object.Error{Message: err.Error()}
+		}
+		if !resultMatchesType(result, f.Return) {
+			return &object.Error{
+				Message: fmt.Sprintf(
+					"function %s returned %s, want %s",
+					name,
+					result.Type(),
+					f.Return,
+				),
+			}
+		}
+		return result.object()
+	}
+}
+
+func resultMatchesType(value Value, typ ValueType) bool {
+	if value.IsNull() {
+		return true
+	}
+	return value.Type() == typ
+}
+
+func validateFunctionName(name string) error {
+	if name == "" {
+		return validationError("function name is required")
+	}
+	if strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") || strings.Contains(name, "..") {
+		return validationError("invalid function name `%s`", name)
+	}
+	switch name {
+	case "true", "false", "null", "includes":
+		return validationError("invalid function name `%s`", name)
+	}
+	if !isFunctionNameStart(name[0]) {
+		return validationError("invalid function name `%s`", name)
+	}
+	for i := 1; i < len(name); i++ {
+		if !isFunctionNamePart(name[i]) {
+			return validationError("invalid function name `%s`", name)
+		}
+	}
+	return nil
+}
+
+func isFunctionNameStart(ch byte) bool {
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
+}
+
+func isFunctionNamePart(ch byte) bool {
+	return isFunctionNameStart(ch) || '0' <= ch && ch <= '9' || ch == '.'
+}
+
+func reservedFunctionName(name string) bool {
+	root := name
+	if idx := strings.IndexByte(name, '.'); idx >= 0 {
+		root = name[:idx]
+	}
+
+	switch root {
+	case "build", "env", "organization", "pipeline", "step":
+		return true
+	default:
+		return false
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,254 @@
+package conditional
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCustomFunctionOption(t *testing.T) {
+	startsWith := WithFunction("starts_with", Function{
+		Args:   []ValueType{StringType, StringType},
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return NullValue(), errors.New("value must be a string")
+			}
+			prefix, ok := args[1].AsString()
+			if !ok {
+				return NullValue(), errors.New("prefix must be a string")
+			}
+			return BoolValue(strings.HasPrefix(value, prefix)), nil
+		},
+	})
+
+	ctx := Context{Build: Build{Branch: str("main")}}
+	expression := `starts_with(build.branch, "ma")`
+
+	if err := Validate(expression, ctx, startsWith); err != nil {
+		t.Fatalf("Validate(%q) returned error: %v", expression, err)
+	}
+
+	got, err := Evaluate(expression, ctx, startsWith)
+	if err != nil {
+		t.Fatalf("Evaluate(%q) returned error: %v", expression, err)
+	}
+	if !got {
+		t.Fatalf("Evaluate(%q) = false, want true", expression)
+	}
+}
+
+func TestEvaluatorUsesReusableOptions(t *testing.T) {
+	startsWith := WithFunction("starts_with", Function{
+		Args:   []ValueType{StringType, StringType},
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return NullValue(), errors.New("value must be a string")
+			}
+			prefix, ok := args[1].AsString()
+			if !ok {
+				return NullValue(), errors.New("prefix must be a string")
+			}
+			return BoolValue(strings.HasPrefix(value, prefix)), nil
+		},
+	})
+
+	evaluator, err := NewEvaluator(startsWith)
+	if err != nil {
+		t.Fatalf("NewEvaluator returned error: %v", err)
+	}
+
+	ctx := Context{Build: Build{Branch: str("main")}}
+	expression := `starts_with(build.branch, "ma")`
+
+	if err := evaluator.Validate(expression, ctx); err != nil {
+		t.Fatalf("Evaluator.Validate(%q) returned error: %v", expression, err)
+	}
+
+	got, err := evaluator.Evaluate(expression, ctx)
+	if err != nil {
+		t.Fatalf("Evaluator.Evaluate(%q) returned error: %v", expression, err)
+	}
+	if !got {
+		t.Fatalf("Evaluator.Evaluate(%q) = false, want true", expression)
+	}
+}
+
+func TestEvaluatorZeroValueRejectsUnknownFunction(t *testing.T) {
+	var evaluator Evaluator
+
+	err := evaluator.Validate(`starts_with("main", "ma")`, Context{})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Evaluator.Validate error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestNewEvaluatorValidatesOptions(t *testing.T) {
+	_, err := NewEvaluator(WithFunction("env", Function{
+		Args:   []ValueType{StringType},
+		Return: StringType,
+		Eval: func(args []Value) (Value, error) {
+			return StringValue("x"), nil
+		},
+	}))
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("NewEvaluator error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestCustomFunctionReturnsComparableValue(t *testing.T) {
+	lower := WithFunction("lower", Function{
+		Args:   []ValueType{StringType},
+		Return: StringType,
+		Eval: func(args []Value) (Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return NullValue(), errors.New("argument must be a string")
+			}
+			return StringValue(strings.ToLower(value)), nil
+		},
+	})
+
+	got, err := Evaluate(`lower("MAIN") == "main"`, Context{}, lower)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !got {
+		t.Fatal("Evaluate = false, want true")
+	}
+}
+
+func TestUnknownFunctionStillFailsWithoutOption(t *testing.T) {
+	err := Validate(`starts_with("main", "ma")`, Context{})
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestCustomFunctionArgumentValidation(t *testing.T) {
+	startsWith := WithFunction("starts_with", Function{
+		Args:   []ValueType{StringType, StringType},
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			return BoolValue(true), nil
+		},
+	})
+
+	err := Validate(`starts_with(1, "ma")`, Context{}, startsWith)
+	if !IsErrorKind(err, ErrorKindValidation) {
+		t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
+	}
+}
+
+func TestCustomFunctionEvaluationError(t *testing.T) {
+	explode := WithFunction("explode", Function{
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			return NullValue(), errors.New("boom")
+		},
+	})
+
+	_, err := Evaluate(`explode()`, Context{}, explode)
+	if !IsErrorKind(err, ErrorKindEvaluation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindEvaluation)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("Evaluate error = %v, want message containing boom", err)
+	}
+}
+
+func TestCustomFunctionEvaluationErrorInNotificationFailsClosed(t *testing.T) {
+	explode := WithFunction("explode", Function{
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			return NullValue(), errors.New("boom")
+		},
+	})
+
+	got, err := Evaluate(`explode()`, Context{EntryPoint: EntryPointBuildNotification}, explode)
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if got {
+		t.Fatal("Evaluate = true, want false")
+	}
+}
+
+func TestCustomFunctionOptionValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		option Option
+	}{
+		{
+			name: "reserved built in function",
+			option: WithFunction("env", Function{
+				Args:   []ValueType{StringType},
+				Return: StringType,
+				Eval: func(args []Value) (Value, error) {
+					return StringValue("x"), nil
+				},
+			}),
+		},
+		{
+			name: "reserved build namespace",
+			option: WithFunction("build.custom", Function{
+				Return: BoolType,
+				Eval: func(args []Value) (Value, error) {
+					return BoolValue(true), nil
+				},
+			}),
+		},
+		{
+			name: "invalid function name",
+			option: WithFunction(".custom", Function{
+				Return: BoolType,
+				Eval: func(args []Value) (Value, error) {
+					return BoolValue(true), nil
+				},
+			}),
+		},
+		{
+			name: "missing eval callback",
+			option: WithFunction("custom", Function{
+				Return: BoolType,
+			}),
+		},
+		{
+			name: "missing return type",
+			option: WithFunction("custom", Function{
+				Eval: func(args []Value) (Value, error) {
+					return BoolValue(true), nil
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(`true`, Context{}, tt.option)
+			if !IsErrorKind(err, ErrorKindValidation) {
+				t.Fatalf("Validate error = %v, want %s", err, ErrorKindValidation)
+			}
+		})
+	}
+}
+
+func TestCustomFunctionReturnTypeValidation(t *testing.T) {
+	badReturn := WithFunction("bad_return", Function{
+		Return: BoolType,
+		Eval: func(args []Value) (Value, error) {
+			return StringValue("not a bool"), nil
+		},
+	})
+
+	_, err := Evaluate(`bad_return()`, Context{}, badReturn)
+	if !IsErrorKind(err, ErrorKindEvaluation) {
+		t.Fatalf("Evaluate error = %v, want %s", err, ErrorKindEvaluation)
+	}
+	if !strings.Contains(err.Error(), "returned string, want boolean") {
+		t.Fatalf("Evaluate error = %v, want return type message", err)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -121,6 +121,35 @@ func TestCustomFunctionReturnsComparableValue(t *testing.T) {
 	}
 }
 
+func TestCustomFunctionAcceptsEnumStringArgument(t *testing.T) {
+	lower := WithFunction("lower", Function{
+		Args:   []ValueType{StringType},
+		Return: StringType,
+		Eval: func(args []Value) (Value, error) {
+			value, ok := args[0].AsString()
+			if !ok {
+				return NullValue(), errors.New("argument must be a string")
+			}
+			return StringValue(strings.ToLower(value)), nil
+		},
+	})
+
+	ctx := Context{Build: Build{State: str("passed")}}
+	expression := `lower(build.state) == "passed"`
+
+	if err := Validate(expression, ctx, lower); err != nil {
+		t.Fatalf("Validate(%q) returned error: %v", expression, err)
+	}
+
+	got, err := Evaluate(expression, ctx, lower)
+	if err != nil {
+		t.Fatalf("Evaluate(%q) returned error: %v", expression, err)
+	}
+	if !got {
+		t.Fatalf("Evaluate(%q) = false, want true", expression)
+	}
+}
+
 func TestUnknownFunctionStillFailsWithoutOption(t *testing.T) {
 	err := Validate(`starts_with("main", "ma")`, Context{})
 	if !IsErrorKind(err, ErrorKindValidation) {

--- a/typecheck.go
+++ b/typecheck.go
@@ -39,10 +39,10 @@ type typeChecker struct {
 	functions map[string]functionSignature
 }
 
-func typeCheckExpression(expr ast.Expression, ctx Context) error {
+func typeCheckExpression(expr ast.Expression, ctx Context, options optionSet) error {
 	checker := typeChecker{
 		variables: variableTypes(ctx),
-		functions: functionTypes(),
+		functions: functionTypes(options),
 	}
 
 	got, err := checker.check(expr)
@@ -274,8 +274,8 @@ func variableTypes(ctx Context) map[string]valueType {
 	return variables
 }
 
-func functionTypes() map[string]functionSignature {
-	return map[string]functionSignature{
+func functionTypes(options optionSet) map[string]functionSignature {
+	functions := map[string]functionSignature{
 		"env": {
 			args: []valueKind{kindString},
 			ret:  stringType(),
@@ -285,6 +285,15 @@ func functionTypes() map[string]functionSignature {
 			ret:  stringType(),
 		},
 	}
+	for name, function := range options.functions {
+		signature, err := function.signature()
+		if err != nil {
+			continue
+		}
+		functions[name] = signature
+	}
+
+	return functions
 }
 
 func stringType() valueType {

--- a/typecheck.go
+++ b/typecheck.go
@@ -161,11 +161,29 @@ func (c typeChecker) checkCall(expr *ast.CallExpression) (valueType, error) {
 		)
 	}
 	for i, arg := range expr.Arguments {
-		if err := c.expect(arg, signature.args[i]); err != nil {
+		if err := c.expectCallArgument(arg, signature.args[i]); err != nil {
 			return valueType{kind: kindUnknown}, err
 		}
 	}
 	return signature.ret, nil
+}
+
+func (c typeChecker) expectCallArgument(expr ast.Expression, expected valueKind) error {
+	actual, err := c.check(expr)
+	if err != nil {
+		return err
+	}
+	if actual.kind == kindUnknown {
+		return nil
+	}
+	if expected == kindString && actual.kind == kindString {
+		return nil
+	}
+	if actual.enum == nil && actual.kind == expected {
+		return nil
+	}
+
+	return validationError("unexpected type: expected %s but found %s", describeKinds([]valueKind{expected}), actual.describe())
 }
 
 func (c typeChecker) checkComparisonTypes(left, right ast.Expression) (valueType, error) {


### PR DESCRIPTION
The library currently treats the Buildkite conditional language as a closed surface: callers can pass Buildkite context and environment, but any caller-owned function name fails validation. That keeps server parity clean, but it makes embedding the evaluator in a larger expression surface awkward.

This change keeps the default Buildkite-parity behavior unchanged while letting callers opt into extra functions. Existing calls like `conditional.Evaluate(expr, ctx)` continue to work, direct per-call options remain available, and `NewEvaluator` lets callers validate options once and reuse them across many expressions:

```go
startsWith := conditional.WithFunction("starts_with", conditional.Function{
	Args:   []conditional.ValueType{conditional.StringType, conditional.StringType},
	Return: conditional.BoolType,
	Eval: func(args []conditional.Value) (conditional.Value, error) {
		value, _ := args[0].AsString()
		prefix, _ := args[1].AsString()
		return conditional.BoolValue(strings.HasPrefix(value, prefix)), nil
	},
})

evaluator, err := conditional.NewEvaluator(startsWith)
if err != nil {
	return err
}

ok, err := evaluator.Evaluate(`starts_with(build.branch, "release/")`, ctx)
```

The extension layer includes typed values, function signatures, runtime conversion, return-type enforcement, and reserved Buildkite roots so custom functions cannot replace built-in `build`, `env`, `organization`, `pipeline`, or `step` behavior. The README and package docs now describe both per-call options and reusable evaluators, and the godoc examples exercise the public API from an external package.